### PR TITLE
Add warning about turning off the logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ The log files are named `/var/run/sqm/${interface_name}.debug.log` e.g. `/var/ru
 - **WARNING:** The commands above leave logging enabled.
 The resulting log file(s) will continue to grow without limit unless you 
 turn logging off or delete/trim these log files on a regular basis.
-When you have finished debugging SQM, use the SQM-QoS web GUI, or issue this command:
+When you have finished debugging SQM, issue this command:
 
     `SQM_DEBUG=0 SQM_VERBOSITY=0 /etc/init.d/sqm start`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The log files are named `/var/run/sqm/${interface_name}.debug.log` e.g. `/var/ru
 
 #### Examples
 
-- Log only the binary invocations and their output:
+- Log only when the binary runs and their output:
 
     `/etc/init.d/sqm stop ; SQM_DEBUG=1 SQM_VERBOSITY=0 /etc/init.d/sqm start`
 
@@ -65,4 +65,9 @@ The log files are named `/var/run/sqm/${interface_name}.debug.log` e.g. `/var/ru
 
     `SQM_DEBUG=1 SQM_VERBOSITY=8 /etc/init.d/sqm stop ; SQM_DEBUG=1 SQM_VERBOSITY=8 /etc/init.d/sqm start`
 
-Note: This always appends to the log file(s), so be sure to turn off debugging (enter `SQM_DEBUG=0`) or remember to save/delete these log files before they get too large.
+- **WARNING:** The commands above leave logging enabled.
+The resulting log file(s) will continue to grow without limit unless you 
+turn logging off or delete/trim these log files on a regular basis.
+When you have finished debugging SQM, issue this command:
+
+    `SQM_DEBUG=0 SQM_VERBOSITY=0 /etc/init.d/sqm start`

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ The log files are named `/var/run/sqm/${interface_name}.debug.log` e.g. `/var/ru
 - **WARNING:** The commands above leave logging enabled.
 The resulting log file(s) will continue to grow without limit unless you 
 turn logging off or delete/trim these log files on a regular basis.
-When you have finished debugging SQM, issue this command:
+When you have finished debugging SQM, use the SQM-QoS web GUI, or issue this command:
 
     `SQM_DEBUG=0 SQM_VERBOSITY=0 /etc/init.d/sqm start`


### PR DESCRIPTION
I did it wrong the first time :-(

I only typed SQM_DEBUG=0, then went merrily on my way. This, of course, left the debugging turned on. I updated the debugging command section to give a final "turning it off" step. 