### PR TITLE
Add some burstability to HTB without so much downside

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -34,6 +34,7 @@
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv4"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv4"
+[ -z "$SHAPER_BURST" ] && SHAPER_BURST="0"
 
 # Logging verbosity
 VERBOSITY_SILENT=0

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -55,7 +55,7 @@ run_sqm_scripts() {
     export TARGET=$(config_get "$section" target)
     export SQUASH_DSCP=$(config_get "$section" squash_dscp)
     export SQUASH_INGRESS=$(config_get "$section" squash_ingress)
-
+    export SHAPER_BURST=$(config_get "$section" shaper_burst)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)
 

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -106,18 +106,20 @@ egress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-
+    BURST="`get_htb_burst $IFACE $CEIL`"
+    
     $TC qdisc del dev $IFACE root 2> /dev/null
+    
     case $QDISC in
         cake*) cake_egress; return;;
     esac
 
     $TC qdisc add dev $IFACE root handle 1: `get_stab_string` htb default 12
-    $TC class add dev $IFACE parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
-    $TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit $BURST `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit $BURST prio 0 `get_htb_adsll_string`
     $TC class add dev $IFACE parent 1:1 classid 1:11 htb $LQ rate 128kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
-    $TC class add dev $IFACE parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
-    $TC class add dev $IFACE parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit $BURST prio 2 `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit $BURST prio 3 `get_htb_adsll_string`
 
     $TC qdisc add dev $IFACE parent 1:11 handle 110: $QDISC \
         `get_limit ${ELIMIT}` `get_target "${ETARGET}" ${UPLINK}` `get_ecn ${EECN}` `get_quantum 300` `get_flows ${PRIO_RATE}` ${EQDISC_OPTS}
@@ -182,7 +184,8 @@ ingress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-
+    BURST="`get_htb_burst $IFACE $CEIL`"
+    
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress
 
@@ -195,18 +198,18 @@ ingress() {
     if [ "$SQUASH_INGRESS" = "1" ]; then
         sqm_debug "Do not perform DSCP based filtering on ingress. (1-tier classification)"
         $TC qdisc add dev $DEV root handle 1: `get_stab_string` htb default 10
-        $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit `get_htb_adsll_string`
-        $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit prio 0 `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit $BURST `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit $BURST prio 0 `get_htb_adsll_string`
         $TC qdisc add dev $DEV parent 1:10 handle 110: $QDISC \
             `get_limit ${ILIMIT}` `get_target "${ITARGET}" ${DOWNLINK}` `get_ecn ${IECN}` `get_flows ${DOWNLINK}` ${IQDISC_OPTS}
     else
         sqm_debug "Perform DSCP based filtering on ingress. (3-tier classification)"
         $TC qdisc add dev $DEV root handle 1: `get_stab_string` htb default 12
-        $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit `get_htb_adsll_string`
-        $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit prio 0 `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit $BURST `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${CEIL}kbit ceil ${CEIL}kbit $BURST prio 0 `get_htb_adsll_string`
         $TC class add dev $DEV parent 1:1 classid 1:11 htb $LQ rate 32kbit ceil ${PRIO_RATE}kbit prio 1 `get_htb_adsll_string`
-        $TC class add dev $DEV parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit prio 2 `get_htb_adsll_string`
-        $TC class add dev $DEV parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit prio 3 `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1:1 classid 1:12 htb $LQ rate ${BE_RATE}kbit ceil ${BE_CEIL}kbit $BURST prio 2 `get_htb_adsll_string`
+        $TC class add dev $DEV parent 1:1 classid 1:13 htb $LQ rate ${BK_RATE}kbit ceil ${BE_CEIL}kbit $BURST prio 3 `get_htb_adsll_string`
 
         $TC qdisc add dev $DEV parent 1:11 handle 110: $QDISC \
             `get_limit ${ILIMIT}` `get_target "${ITARGET}" ${DOWNLINK}` `get_ecn ${IECN}` `get_quantum 500` `get_flows ${PRIO_RATE}` ${IQDISC_OPTS}

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -35,15 +35,17 @@ cake_egress()
 egress() {
 
     LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
-
+    BURST="`get_htb_burst $IFACE ${UPLINK}`"
+    
     $TC qdisc del dev $IFACE root 2>/dev/null
+    
     case $QDISC in
         cake*) cake_egress; return ;;
     esac
 
     $TC qdisc add dev $IFACE root handle 1: `get_stab_string` htb default 10
-    $TC class add dev $IFACE parent 1: classid 1:1 htb $LQ rate ${UPLINK}kbit ceil ${UPLINK}kbit `get_htb_adsll_string`
-    $TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ rate ${UPLINK}kbit ceil ${UPLINK}kbit prio 0 `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1: classid 1:1 htb $LQ rate ${UPLINK}kbit ceil ${UPLINK}kbit $BURST `get_htb_adsll_string`
+    $TC class add dev $IFACE parent 1:1 classid 1:10 htb $LQ rate ${UPLINK}kbit ceil ${UPLINK}kbit $BURST prio 0 `get_htb_adsll_string`
     $TC qdisc add dev $IFACE parent 1:10 handle 110: $QDISC \
         `get_limit ${ELIMIT}` `get_target "${ETARGET}" ${UPLINK}` `get_ecn ${EECN}` `get_flows ${UPLINK}` ${EQDISC_OPTS}
 
@@ -66,7 +68,8 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
-
+    BURST="`get_htb_burst $IFACE ${DOWNLINK}`"
+    
     $TC qdisc del dev $DEV root 2>/dev/null
 
     case $QDISC in
@@ -74,8 +77,8 @@ ingress() {
     esac
 
     $TC qdisc add dev $DEV root handle 1: `get_stab_string` htb default 10
-    $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit `get_htb_adsll_string`
-    $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit prio 0 `get_htb_adsll_string`
+    $TC class add dev $DEV parent 1: classid 1:1 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit $BURST `get_htb_adsll_string`
+    $TC class add dev $DEV parent 1:1 classid 1:10 htb $LQ rate ${DOWNLINK}kbit ceil ${DOWNLINK}kbit $BURST prio 0 `get_htb_adsll_string`
 
     # FIXME: I'd prefer to use a pre-nat filter but we need to detect if nat is on this interface
     # AND we need to permute by a random number which we can't do from userspace filters


### PR DESCRIPTION
As discussed at length, HTB is configured to optimize delay in SQM. However at high CPU load, the default burst (MTU+S&H) does not bridge interrupt cycles and bandwidth is lost in the dead space. There were hints burst would be easy to tune, and in theory it might almost be. Yet the high CPU load creates interrupts-interrupting-other-interrupts. The burst buffer can get left in limbo waiting to commit. I did find a compromise which seems to have no noticeable effect on delay. It will fall short of maximum speed, but such is the trade off. (1) default, HTB needs to burst MTU+S&H. (2) HTB can burst first 2xMTU if less then 1ms. (3) All additional NxMTU must add in 500us equivalent each. (4) 10 MTU is the maximum.

Commit [55e4a2c](https://github.com/tohojo/sqm-scripts/commit/55e4a2c2242e8b61e72489be0322f2c82cdf5248)
- Fix white space in functions.sh for navigation (regex: 4 spaces seemed most common)
- Add get_htb_burst() to compute above and push "burst X cburst X" if needed
- Add burst string macro to simplest.qos and simple.qos
- No bursting to priority band in simple.qos as it is hard coded <1mbps
- Add UCI option "shaper_burst" default "0" or disabled to run-openwrt.sh and default.sh
- No Luci. I assume testing will be desired on a hidden option for awhile.

Commit [188fa2d](https://github.com/tohojo/sqm-scripts/commit/188fa2db0fc62d6fe02087eff4164d3cdfe8a90d)
- Compute HTB quantum with similar method to burst
- @Sebastian, this seems it was your TODO so let me know ...
- The scale factor appears not quite right as I have it.
- Were you aiming for a quadratic curve?
