### PR TITLE
Makefile: Use macros to leverage install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 PREFIX:=/usr
 DESTDIR:=
 PLATFORM:=linux
-LUCI_DIR:=$(DESTDIR)$(PREFIX)/lib/lua/luci
+sbindir:=$(DESTDIR)$(PREFIX)/sbin
+sysconfdir:=$(DESTDIR)/etc
+libdir:=$(DESTDIR)$(PREFIX)/lib
+LUCI_DIR:=$(libdir)/lua/luci
 
 all:
 	@echo "Run 'make install' to install."
@@ -12,39 +15,36 @@ install: install-$(PLATFORM)
 .PHONY: install-openwrt
 
 install-openwrt: install-lib
-	install -m 0755 -d $(DESTDIR)/etc/hotplug.d/iface $(DESTDIR)/etc/config \
-		$(DESTDIR)/etc/init.d
-	install -m 0755 platform/openwrt/sqm-hotplug $(DESTDIR)/etc/hotplug.d/iface/11-sqm
-	install -m 0755 platform/openwrt/sqm-init $(DESTDIR)/etc/init.d/sqm
-	install -m 0644 platform/openwrt/sqm-uci $(DESTDIR)/etc/config/sqm
-	install -m 0744 src/run-openwrt.sh $(DESTDIR)$(PREFIX)/lib/sqm/run.sh
+	install -m 0755 -d $(sysconfdir)/hotplug.d/iface $(sysconfdir)/config \
+		$(sysconfdir)/init.d
+	install -m 0755 platform/openwrt/sqm-hotplug $(sysconfdir)/hotplug.d/iface/11-sqm
+	install -m 0755 platform/openwrt/sqm-init $(sysconfdir)/init.d/sqm
+	install -m 0644 platform/openwrt/sqm-uci $(sysconfdir)/config/sqm
+	install -m 0744 src/run-openwrt.sh $(libdir)/sqm/run.sh
 
 install-linux: install-lib
-	install -m 0755 -d $(DESTDIR)$(PREFIX)/lib/systemd/system \
-		$(DESTDIR)$(PREFIX)/lib/tmpfiles.d $(DESTDIR)$(PREFIX)/bin
-	install -m 0644  platform/linux/eth0.iface.conf.example $(DESTDIR)/etc/sqm
-	install -m 0644  platform/linux/sqm@.service \
-		$(DESTDIR)$(PREFIX)/lib/systemd/system
-	install -m 0644  platform/linux/sqm-tmpfiles.conf \
-		$(DESTDIR)$(PREFIX)/lib/tmpfiles.d/sqm.conf
-	install -m 0755 platform/linux/sqm-bin $(DESTDIR)$(PREFIX)/bin/sqm
-	test -d $(DESTDIR)/etc/network/if-up.d && install -m 0755 platform/linux/sqm-ifup \
-		$(DESTDIR)/etc/network/if-up.d/sqm || exit 0
+	install -m 0755 -d $(sbindir)
+	install -m 0644 platform/linux/eth0.iface.conf.example $(sysconfdir)/sqm
+	install -m 0755 platform/linux/sqm-bin $(sbindir)/sqm
+	test -d $(libdir)/systemd/system && install -m 0644 platform/linux/sqm@.service \
+                $(libdir)/systemd/system || exit 0
+	test -d $(sysconfdir)/network/if-up.d && install -m 0755 platform/linux/sqm-ifup \
+		$(sysconfdir)/network/if-up.d/sqm || exit 0
 
 .PHONY: install-lib
 
 install-lib:
-	install -m 0755 -d $(DESTDIR)/etc/sqm $(DESTDIR)$(PREFIX)/lib/sqm
-	install -m 0644 platform/$(PLATFORM)/sqm.conf $(DESTDIR)/etc/sqm/sqm.conf
+	install -m 0755 -d $(sysconfdir)/sqm $(libdir)/sqm
+	install -m 0644 platform/$(PLATFORM)/sqm.conf $(sysconfdir)/sqm/sqm.conf
 	install -m 0644  src/functions.sh src/defaults.sh \
-		src/*.qos src/*.help $(DESTDIR)$(PREFIX)/lib/sqm
+		src/*.qos src/*.help $(libdir)/sqm
 	install -m 0744  src/start-sqm src/stop-sqm src/update-available-qdiscs \
-		$(DESTDIR)$(PREFIX)/lib/sqm
+		$(libdir)/sqm
 
 .PHONY: install-luci
 install-luci:
 	install -m 0755 -d $(LUCI_DIR)/controller $(LUCI_DIR)/model/cbi
 	install -m 0644 luci/sqm-controller.lua $(LUCI_DIR)/controller/sqm.lua
 	install -m 0644 luci/sqm-cbi.lua $(LUCI_DIR)/model/cbi/sqm.lua
-	install -m 0755 -d $(DESTDIR)/etc/uci-defaults
-	install -m 0755 luci/uci-defaults-sqm $(DESTDIR)/etc/uci-defaults/luci-sqm
+	install -m 0755 -d $(sysconfdir)/uci-defaults
+	install -m 0755 luci/uci-defaults-sqm $(sysconfdir)/uci-defaults/luci-sqm

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ DESTDIR:=
 PLATFORM:=linux
 sbindir:=$(DESTDIR)$(PREFIX)/sbin
 sysconfdir:=$(DESTDIR)/etc
-libdir:=$(DESTDIR)$(PREFIX)/lib
-LUCI_DIR:=$(libdir)/lua/luci
+datadir:=$(DESTDIR)$(PREFIX)/share
+LUCI_DIR:=$(datadir)/lua/luci
 
 all:
 	@echo "Run 'make install' to install."
@@ -20,26 +20,26 @@ install-openwrt: install-lib
 	install -m 0755 platform/openwrt/sqm-hotplug $(sysconfdir)/hotplug.d/iface/11-sqm
 	install -m 0755 platform/openwrt/sqm-init $(sysconfdir)/init.d/sqm
 	install -m 0644 platform/openwrt/sqm-uci $(sysconfdir)/config/sqm
-	install -m 0744 src/run-openwrt.sh $(libdir)/sqm/run.sh
+	install -m 0744 src/run-openwrt.sh $(datadir)/sqm/run.sh
 
 install-linux: install-lib
 	install -m 0755 -d $(sbindir)
 	install -m 0644 platform/linux/eth0.iface.conf.example $(sysconfdir)/sqm
 	install -m 0755 platform/linux/sqm-bin $(sbindir)/sqm
-	test -d $(libdir)/systemd/system && install -m 0644 platform/linux/sqm@.service \
-                $(libdir)/systemd/system || exit 0
+	test -d $(datadir)/systemd/system && install -m 0644 platform/linux/sqm@.service \
+                $(datadir)/systemd/system || exit 0
 	test -d $(sysconfdir)/network/if-up.d && install -m 0755 platform/linux/sqm-ifup \
 		$(sysconfdir)/network/if-up.d/sqm || exit 0
 
 .PHONY: install-lib
 
 install-lib:
-	install -m 0755 -d $(sysconfdir)/sqm $(libdir)/sqm
+	install -m 0755 -d $(sysconfdir)/sqm $(datadir)/sqm
 	install -m 0644 platform/$(PLATFORM)/sqm.conf $(sysconfdir)/sqm/sqm.conf
 	install -m 0644  src/functions.sh src/defaults.sh \
-		src/*.qos src/*.help $(libdir)/sqm
+		src/*.qos src/*.help $(datadir)/sqm
 	install -m 0744  src/start-sqm src/stop-sqm src/update-available-qdiscs \
-		$(libdir)/sqm
+		$(datadir)/sqm
 
 .PHONY: install-luci
 install-luci:

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ DESTDIR:=
 PLATFORM:=linux
 sbindir:=$(DESTDIR)$(PREFIX)/sbin
 sysconfdir:=$(DESTDIR)/etc
-datadir:=$(DESTDIR)$(PREFIX)/share
-LUCI_DIR:=$(datadir)/lua/luci
+libdir:=$(DESTDIR)$(PREFIX)/lib
+LUCI_DIR:=$(libdir)/lua/luci
 
 all:
 	@echo "Run 'make install' to install."
@@ -20,26 +20,26 @@ install-openwrt: install-lib
 	install -m 0755 platform/openwrt/sqm-hotplug $(sysconfdir)/hotplug.d/iface/11-sqm
 	install -m 0755 platform/openwrt/sqm-init $(sysconfdir)/init.d/sqm
 	install -m 0644 platform/openwrt/sqm-uci $(sysconfdir)/config/sqm
-	install -m 0744 src/run-openwrt.sh $(datadir)/sqm/run.sh
+	install -m 0744 src/run-openwrt.sh $(libdir)/sqm/run.sh
 
 install-linux: install-lib
 	install -m 0755 -d $(sbindir)
 	install -m 0644 platform/linux/eth0.iface.conf.example $(sysconfdir)/sqm
 	install -m 0755 platform/linux/sqm-bin $(sbindir)/sqm
-	test -d $(datadir)/systemd/system && install -m 0644 platform/linux/sqm@.service \
-                $(datadir)/systemd/system || exit 0
+	test -d $(libdir)/systemd/system && install -m 0644 platform/linux/sqm@.service \
+                $(libdir)/systemd/system || exit 0
 	test -d $(sysconfdir)/network/if-up.d && install -m 0755 platform/linux/sqm-ifup \
 		$(sysconfdir)/network/if-up.d/sqm || exit 0
 
 .PHONY: install-lib
 
 install-lib:
-	install -m 0755 -d $(sysconfdir)/sqm $(datadir)/sqm
+	install -m 0755 -d $(sysconfdir)/sqm $(libdir)/sqm
 	install -m 0644 platform/$(PLATFORM)/sqm.conf $(sysconfdir)/sqm/sqm.conf
 	install -m 0644  src/functions.sh src/defaults.sh \
-		src/*.qos src/*.help $(datadir)/sqm
+		src/*.qos src/*.help $(libdir)/sqm
 	install -m 0744  src/start-sqm src/stop-sqm src/update-available-qdiscs \
-		$(datadir)/sqm
+		$(libdir)/sqm
 
 .PHONY: install-luci
 install-luci:

--- a/luci/sqm-cbi.lua
+++ b/luci/sqm-cbi.lua
@@ -19,7 +19,7 @@ local net = require "luci.model.network".init()
 local sys = require "luci.sys"
 --local ifaces = net:get_interfaces()
 local ifaces = sys.net:devices()
-local path = "/usr/lib/sqm"
+local path = "/usr/share/sqm"
 local run_path = "/tmp/run/sqm/available_qdiscs"
 
 m = Map("sqm", translate("Smart Queue Management"),

--- a/platform/linux/sqm.conf
+++ b/platform/linux/sqm.conf
@@ -1,4 +1,4 @@
-SQM_LIB_DIR=/usr/lib/sqm
+SQM_LIB_DIR=/usr/share/sqm
 SQM_STATE_DIR=/run/sqm
 SQM_QDISC_STATE_DIR=${SQM_STATE_DIR}/available_qdiscs
 SQM_CHECK_QDISCS="fq_codel codel pie sfq cake"

--- a/platform/linux/sqm@.service
+++ b/platform/linux/sqm@.service
@@ -9,8 +9,8 @@ After=sys-subsystem-net-devices-%i.device
 Type=oneshot
 EnvironmentFile=/etc/sqm/%i.iface.conf
 Environment=IFACE=%i ENABLED=1
-ExecStart=/usr/lib/sqm/start-sqm
-ExecStop=/usr/lib/sqm/stop-sqm
+ExecStart=/usr/share/sqm/start-sqm
+ExecStop=/usr/share/sqm/stop-sqm
 RemainAfterExit=1
 
 [Install]

--- a/platform/openwrt/sqm-hotplug
+++ b/platform/openwrt/sqm-hotplug
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-[ "$ACTION" = ifup ] && /etc/init.d/sqm enabled && /usr/lib/sqm/run.sh start ${DEVICE}
+[ "$ACTION" = ifup ] && /etc/init.d/sqm enabled && /usr/share/sqm/run.sh start ${DEVICE}

--- a/platform/openwrt/sqm-init
+++ b/platform/openwrt/sqm-init
@@ -14,10 +14,10 @@ restart()
 
 start()
 {
-    /usr/lib/sqm/run.sh start
+    /usr/share/sqm/run.sh start
 }
 
 stop()
 {
-    /usr/lib/sqm/run.sh stop
+    /usr/share/sqm/run.sh stop
 }

--- a/platform/openwrt/sqm.conf
+++ b/platform/openwrt/sqm.conf
@@ -1,4 +1,4 @@
-SQM_LIB_DIR=/usr/lib/sqm
+SQM_LIB_DIR=/usr/share/sqm
 SQM_STATE_DIR=/var/run/sqm
 SQM_QDISC_STATE_DIR=${SQM_STATE_DIR}/available_qdiscs
 SQM_CHECK_QDISCS="fq_codel efq_codel nfq_codel sfq codel ns2_codel pie sfq cake"

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -7,7 +7,7 @@
 #       Copyright (C) 2012-4 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 
-. /lib/functions.sh
+. /usr/share/sqm/functions.sh
 
 . /etc/sqm/sqm.conf
 


### PR DESCRIPTION
- Makes extensive use of standard Makefile macros
- Only installs systemD pieces if systemD is detected in system
- No longer installs $(PREFIX)/lib/tmpfiles.d/sqm.conf (did not
  find a use for that file in existing scripts)