### PR TITLE
Makefile: Take advantage of macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,45 @@
 PREFIX:=/usr
-DESTDIR:=
 PLATFORM:=linux
-LUCI_DIR:=$(DESTDIR)$(PREFIX)/lib/lua/luci
+sysconfdir:=$(DESTDIR)/etc
+libdir:=$(DESTDIR)$(PREFIX)/lib
+sbindir:=$(DESTDIR)$(PREFIX)/bin
+LUCI_DIR:=$(libdir)/lua/luci
 
 all:
 	@echo "Run 'make install' to install."
 
 install: install-$(PLATFORM)
 
-
 .PHONY: install-openwrt
-
 install-openwrt: install-lib
-	install -m 0755 -d $(DESTDIR)/etc/hotplug.d/iface $(DESTDIR)/etc/config \
-		$(DESTDIR)/etc/init.d
-	install -m 0755 platform/openwrt/sqm-hotplug $(DESTDIR)/etc/hotplug.d/iface/11-sqm
-	install -m 0755 platform/openwrt/sqm-init $(DESTDIR)/etc/init.d/sqm
-	install -m 0644 platform/openwrt/sqm-uci $(DESTDIR)/etc/config/sqm
-	install -m 0744 src/run-openwrt.sh $(DESTDIR)$(PREFIX)/lib/sqm/run.sh
+	install -d $(sysconfdir)/hotplug.d/iface $(sysconfdir)/init.d \
+		$(sysconfdir)/config $(libdir)/sqm
+	install -m 0755 platform/$(PLATFORM)/sqm-hotplug $(sysconfdir)/hotplug.d/iface/11-sqm
+	install -m 0755 platform/$(PLATFORM)/sqm-init $(sysconfdir)/init.d/sqm
+	install -m 0644 platform/$(PLATFORM)/sqm-uci $(sysconfdir)/config/sqm
+	install -m 0744 src/run-openwrt.sh $(libdir)/sqm/run.sh
 
 install-linux: install-lib
-	install -m 0755 -d $(DESTDIR)$(PREFIX)/lib/systemd/system \
-		$(DESTDIR)$(PREFIX)/lib/tmpfiles.d $(DESTDIR)$(PREFIX)/bin
-	install -m 0644  platform/linux/eth0.iface.conf.example $(DESTDIR)/etc/sqm
-	install -m 0644  platform/linux/sqm@.service \
-		$(DESTDIR)$(PREFIX)/lib/systemd/system
-	install -m 0644  platform/linux/sqm-tmpfiles.conf \
-		$(DESTDIR)$(PREFIX)/lib/tmpfiles.d/sqm.conf
-	install -m 0755 platform/linux/sqm-bin $(DESTDIR)$(PREFIX)/bin/sqm
-	test -d $(DESTDIR)/etc/network/if-up.d && install -m 0755 platform/linux/sqm-ifup \
-		$(DESTDIR)/etc/network/if-up.d/sqm || exit 0
+	install -d $(libdir)/systemd/system
+	install -D -m 0644 platform/$(PLATFORM)/eth0.iface.conf.example $(sysconfdir)/sqm
+	install -m 0644 platform/$(PLATFORM)/sqm@.service $(libdir)/systemd/system
+	install -D -m 0644 platform/$(PLATFORM)/sqm-tmpfiles.conf $(libdir)/tmpfiles.d/sqm.conf
+	install -D -m 0755 platform/$(PLATFORM)/sqm-bin $(sbindir)/sqm
+	test -d $(sysconfdir)/network/if-up.d && install -D -m 0755 platform/$(PLATFORM)/sqm-ifup \
+		$(sysconfdir)/network/if-up.d/sqm || exit 0
 
 .PHONY: install-lib
-
 install-lib:
-	install -m 0755 -d $(DESTDIR)/etc/sqm $(DESTDIR)$(PREFIX)/lib/sqm
-	install -m 0644 platform/$(PLATFORM)/sqm.conf $(DESTDIR)/etc/sqm/sqm.conf
-	install -m 0644  src/functions.sh src/defaults.sh \
-		src/*.qos src/*.help $(DESTDIR)$(PREFIX)/lib/sqm
-	install -m 0744  src/start-sqm src/stop-sqm src/update-available-qdiscs \
-		$(DESTDIR)$(PREFIX)/lib/sqm
+	install -d $(libdir)/sqm
+	install -D -m 0644 platform/$(PLATFORM)/sqm.conf $(sysconfdir)/sqm/sqm.conf
+	install -m 0644 src/functions.sh src/defaults.sh \
+		src/*.qos src/*.help $(libdir)/sqm
+	install -m 0744 src/start-sqm src/stop-sqm src/update-available-qdiscs \
+		$(libdir)/sqm
 
 .PHONY: install-luci
 install-luci:
-	install -m 0755 -d $(LUCI_DIR)/controller $(LUCI_DIR)/model/cbi
-	install -m 0644 luci/sqm-controller.lua $(LUCI_DIR)/controller/sqm.lua
-	install -m 0644 luci/sqm-cbi.lua $(LUCI_DIR)/model/cbi/sqm.lua
-	install -m 0755 -d $(DESTDIR)/etc/uci-defaults
-	install -m 0755 luci/uci-defaults-sqm $(DESTDIR)/etc/uci-defaults/luci-sqm
+	install -D -m 0644 luci/sqm-controller.lua $(LUCI_DIR)/controller/sqm.lua
+	install -D -m 0644 luci/sqm-cbi.lua $(LUCI_DIR)/model/cbi/sqm.lua
+	install -D -m 0755 luci/uci-defaults-sqm $(sysconfdir)/uci-defaults/luci-sqm
+


### PR DESCRIPTION
Take advantage of Makefile macros, reducing slightly the Makefile
size and potentially reducing the risk of introducing wrong paths by
using macros.
Testcase: http://pastebin.com/32R3YP2Y

Tested-by: Rodrigo Freire rbs@brasilia.br
Signed-off-by: Rodrigo Freire rbs@brasilia.br
