### PR TITLE
sqm-scripts: Better describe simplest script

### DIFF
--- a/luci/sqm-cbi.lua
+++ b/luci/sqm-cbi.lua
@@ -95,7 +95,7 @@ verb.rmempty = true
 -- QDISC
 
 local val_qdisc_name = ""
-c = s:taboption("tab_qdisc", ListValue, "qdisc", translate("Queuing disciplines useable on this system. After installing a new qdisc, you need to restart the router to see updates!"))
+c = s:taboption("tab_qdisc", ListValue, "qdisc", translate("Queuing disciplines useable on this system. If you have a low bandwidth link (less than 2 Mbps), consider using the HTB queue discipline and 'Simplest' Queue Setup Script. After installing a new qdisc, you need to restart the router to see updates!"))
 c:value("fq_codel", "fq_codel ("..translate("default")..")")
 
 if fs.stat(run_path) then

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -3,10 +3,10 @@
 # simplest.qos (Cero3 Simple Shaper)
 #
 # Abstract:
-# This is a single band fq_codel and ipv6 enabled shaping script for Ethernet
-# gateways. This is nearly the simplest possible. With FQ_CODEL, the sparseness
-# priority will work pretty well for a casual network. Flow-hashes should not
-# overlap much with only a few users.
+# This is a single band ipv6 enabled shaping script for Ethernet gateways.
+# This is nearly the simplest possible. With FQ_CODEL, the sparseness priority
+# will work pretty well for a casual network. Flow-hashes should not overlap
+# much with only a few users.
 #
 # References:
 # This alternate shaper attempts to go for 1/u performance in a clever way

--- a/src/simplest.qos.help
+++ b/src/simplest.qos.help
@@ -1,1 +1,3 @@
 Simplest possible configuration: HTB rate limiter with your qdisc attached.
+This script is also recommended on low bandwidth (less than 2 Mbps) and / or
+systems where other scripts tends to saturate the CPU.


### PR DESCRIPTION
- Better explains the 'simplest' SQM script
- Remove a fq_codel mention in 'simplest' SQM script, hinting that
  it only works with fq_codel (which is not true).

Resolves Issue #39 .

Signed-off-by: Rodrigo Freire <rbs@brasilia.br>