### PR TITLE
Make sqm start later in the boot process

### DIFF
--- a/platform/openwrt/sqm-init
+++ b/platform/openwrt/sqm-init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=50
+START=97
 
 reload()
 {


### PR DESCRIPTION
Make sqm start later in the boot process in order to make sure wan interface is up

Signed-off-by: Daniel Engberg daniel.engberg.lists@pyret.net
