### PR TITLE
rework cake scripts to be wash aware

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -32,8 +32,8 @@
 [ -z "$IPT_MASK" ] && IPT_MASK="0xff" # to disable: set mask to 0xffffffff
 #sm: we need the functions above before trying to set the ingress IFB device
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
-[ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv4"
-[ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv4"
+[ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
+[ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
 [ -z "$SHAPER_BURST" ] && SHAPER_BURST="1"
 [ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -15,51 +15,39 @@
 . ${SQM_LIB_DIR}/defaults.sh
 QDISC=cake
 
-# INGRESS_CAKE_OPTS and EGRESS_CAKE_OPTS are defined in defaults.sh now
-
-
+# Default traffic classication is passed in INGRESS_CAKE_OPTS and EGRESS_CAKE_OPTS, defined in defaults.sh now
 
 
 ipt_setup() {
 
-    ipt -t mangle -N QOS_MARK_${IFACE}
-
     sqm_debug "cake does all the diffserv work - no need for iptables rules"
 
-    # Turn it on. Preserve classification if already performed
-
-    #sm: Since we use an IFB for ingress shaping the TOS bits will not be re-mapped/squashed
-    #	before reaching cake, so we need to tell cake to ignore them, iptables will squash them later.
+    #kdb: cake can choose to use DSCP for classification (none = besteffort, others diffserv3,4 etc)
+    #kdb: and clear those DSCP bits (wash) on egress of the qdisc independently
+    #kdb: FIXME: Permit independent selection of DSCP clearing for ingress/egress qdiscs - needs gui tweak
+    #kdb: these are really horrible, non-intuitive variable names, something like DSCP_INGRESS_ZERO and DSCP_INGRESS_IGNORE ?
+    #kdb: with matching for EGRESS.
     if [ "$SQUASH_DSCP" = "1" ]
     then
-	sqm_debug "Squashing differentiated services code points (DSCP) from ingress."
-	INGRESS_CAKE_OPTS=besteffort # someday squash
-	ipt -t mangle -I PREROUTING -i $IFACE -m dscp ! --dscp 0 -j DSCP --set-dscp-class be
+	sqm_debug "Clearing differentiated services code points (DSCP) from ingress."
+	INGRESS_CAKE_ZERO_OPTS="wash"
+	EGRESS_CAKE_ZERO_OPTS="wash"
     else
 	sqm_debug "Keeping differentiated services code points (DSCP) from ingress."
-	#INGRESS_CAKE_OPTS="diffserv4"
-	ipt -t mangle -A PREROUTING -i $IFACE -m mark --mark 0x00/${IPT_MASK} -g QOS_MARK_${IFACE}
+	INGRESS_CAKE_ZERO_OPTS="" # default is effectively "nowash"
+	EGRESS_CAKE_ZERO_OPTS=""  # default is effectively "nowash"
     fi
 
-    ipt -t mangle -A POSTROUTING -o $IFACE -m mark --mark 0x00/${IPT_MASK} -g QOS_MARK_${IFACE}
-
-    # Not sure if this will work. Encapsulation is a problem period
-    ipt -t mangle -I PREROUTING -i vtun+ -p tcp -j MARK --set-mark 0x2/${IPT_MASK} # tcp tunnels need ordering
-
-    ## Emanating from router, do a little more optimization
-    ## but don't bother with it too much.
-    #sm: actually just keep this as reference in case it should be needed, our 1-tier shaper scripts
-    # work quite well without that "optimization"
-    #ipt -t mangle -A OUTPUT -p udp -m multiport --ports 123,53 -j DSCP --set-dscp-class AF42
 }
 
 
 egress() {
 
+    EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} ${EGRESS_CAKE_ZERO_OPTS}"
+
     $TC qdisc del dev $IFACE root 2> /dev/null
     $TC qdisc add dev $IFACE root $( get_stab_string ) cake bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 
-    #diffserv $IFACE
 }
 
 
@@ -70,16 +58,18 @@ ingress() {
 
     $TC qdisc del dev $DEV root  2> /dev/null
 
+#DSCP_IGNORE
     if [ "$SQUASH_INGRESS" = "1" ]
     then
-	sqm_debug "Do not perform DSCP based filtering on ingress. (1-tier classification)"
-	# Revert to no dscp based filtering
-	INGRESS_CAKE_OPTS="besteffort"
-	$TC qdisc add dev $DEV root $( get_stab_string ) cake bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
+	sqm_debug "Do not perform DSCP based traffic classification on ingress. (single tin)"
+	# Revert to no dscp based classification ie. ignore DSCP
+	INGRESS_CAKE_OPTS="besteffort ${INGRESS_CAKE_ZERO_OPTS}"
     else
-	sqm_debug "Perform DSCP based filtering on ingress. (multi-tier classification)"
-	$TC qdisc add dev $DEV root $( get_stab_string) cake bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) $INGRESS_CAKE_OPTS ${IQDISC_OPTS}
+	sqm_debug "Perform DSCP based traffic classification on ingress. (multi-tier classification)"
+	INGRESS_CAKE_OPTS="${INGRESS_CAKE_OPTS} ${INGRESS_CAKE_ZERO_OPTS}"
     fi
+
+    $TC qdisc add dev $DEV root $( get_stab_string ) cake bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up
 

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Cero3 Simple Shaper
-# A 1 bin cake shaper for
+# A 1 tin cake shaper for
 # ethernet gateways. This is nearly the simplest possible
 
 # This program is free software; you can redistribute it and/or modify
@@ -15,12 +15,36 @@ QDISC=cake
 
 
 # to keep this as simple as possible we ignore the *_CAKE_OPTS from defaults.sh
+# and clear the DSCP bits from ingress & egress
 INGRESS_CAKE_OPTS="besteffort"
 EGRESS_CAKE_OPTS="besteffort"
 
 
+ipt_setup() {
+
+    sqm_debug "cake does all the diffserv work - no need for iptables rules"
+
+    #kdb: cake can choose to use DSCP for classification (none = besteffort, others diffserv3,4 etc)
+    #kdb: and clear those DSCP bits (wash) on egress of the qdisc independently
+    #kdb: FIXME: Permit independent selection of DSCP clearing for ingress/egress qdiscs - needs gui tweak
+    #kdb: these are really horrible, non-intuitive variable names, something like DSCP_INGRESS_ZERO and DSCP_INGRESS_IGNORE ?
+    #kdb: with matching for EGRESS.
+    if [ "$SQUASH_DSCP" = "1" ]
+    then
+	sqm_debug "Clearing differentiated services code points (DSCP) from ingress."
+	INGRESS_CAKE_ZERO_OPTS="wash"
+	EGRESS_CAKE_ZERO_OPTS="wash"
+    else
+	sqm_debug "Keeping differentiated services code points (DSCP) from ingress."
+	INGRESS_CAKE_ZERO_OPTS="" # default is effectively "nowash"
+	EGRESS_CAKE_ZERO_OPTS=""  # default is effectively "nowash"
+    fi
+
+}
+
 egress() {
     sqm_debug "egress"
+    EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} ${EGRESS_CAKE_ZERO_OPTS}"
     $TC qdisc del dev $IFACE root 2>/dev/null
     $TC qdisc add dev $IFACE root $( get_stab_string ) cake bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
@@ -28,6 +52,7 @@ egress() {
 
 ingress() {
     sqm_debug "ingress"
+    INGRESS_CAKE_OPTS="${INGRESS_CAKE_OPTS} ${INGRESS_CAKE_ZERO_OPTS}"
     $TC qdisc del dev $IFACE handle ffff: ingress 2>/dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress
     $TC qdisc del dev $DEV root 2>/dev/null
@@ -49,6 +74,7 @@ sqm_start() {
 
     [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
 
+    ipt_setup
 
     if [ "${UPLINK}" -ne 0 ];
     then


### PR DESCRIPTION
The CAKE qdisc found in LEDE can clear DSCP bits itself rather than relying on iptables rules (and overhead)
