### PR TITLE
sqm-cbi: Add network name hints to interface selection.

### DIFF
--- a/luci/sqm-cbi.lua
+++ b/luci/sqm-cbi.lua
@@ -57,11 +57,21 @@ function e.write(self, section, value)
 end
 -- TODO: inform the user what we just did...
 
+
+-- Add to physical interface list a hint of the correpsonding network names,
+-- used to help users better select e.g. lan or wan interface.
+
 n = s:taboption("tab_basic", ListValue, "interface", translate("Interface name"))
 -- sm lifted from luci-app-wol, the original implementation failed to show pppoe-ge00 type interface names
 for _, iface in ipairs(ifaces) do
 	if not (iface == "lo" or iface:match("^ifb.*")) then
-		n:value(iface)
+		local nets = net:get_interface(iface)
+		nets = nets and nets:get_networks() or {}
+		for k, v in pairs(nets) do
+			nets[k] = nets[k].sid
+		end
+		nets = table.concat(nets, ",")
+		n:value(iface, ((#nets > 0) and "%s (%s)" % {iface, nets} or iface))
 	end
 end
 n.rmempty = false


### PR DESCRIPTION
Since physical interface names vary between models, this helps users
better choose the correct interface e.g. "wan" or "lan".
For example:
![sqm-interface-hints](https://cloud.githubusercontent.com/assets/14342969/22408027/7edc6e50-e626-11e6-869e-433279140d8c.png)

This change is one of several improvements across the SQM stack I've been testing since starting to use cake several months ago, and packaging up sqm-scripts for OpenWRT CC routers of friends/family .  Note these changes use the (unfortunately) undocumented 'luci.model.network' module.  My first attempts at providing these hints, before discovering this module, were much larger and more complicated.

Comments or feedback appreciated.
