### PR TITLE
run-openwrt.sh: last queue disabled and /etc/init.d/sqm restart fix

### DIFF
--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -31,7 +31,7 @@ start_sqm_section() {
     export IFACE=$(config_get "$section" interface)
 
     [ -z "$RUN_IFACE" -o "$RUN_IFACE" = "$IFACE" ] || return
-    [ "$(config_get "$section" enabled)" -eq 1 ] || return
+    [ "$(config_get "$section" enabled)" -eq 1 ] || return 0
     [ -f "${SQM_STATE_DIR}/${IFACE}.state" ] && return
 
     export UPLINK=$(config_get "$section" upload)


### PR DESCRIPTION
Calling /etc/init.d/sqm (re)start failed (retval=1)
when the option enabled in the last section queue was set to '0'.
This behaviour was fixed so that a 0 is returned after calling
/etc/init.d/sqm (re)start when the last queue is not enabled.

> /etc/config/sqm
```
config queue 'eth0'
        option enabled '1'
        option interface 'eth0'
        option download '85000'
        option upload '10000'
        option qdisc 'fq_codel'
        option script 'simple.qos'
        option qdisc_advanced '0'
        option ingress_ecn 'ECN'
        option egress_ecn 'ECN'
        option qdisc_really_really_advanced '0'
        option itarget 'auto'
        option etarget 'auto'
        option linklayer 'none'

config queue 'eth1'
        option enabled '0'
        option interface 'eth1'
        option download '85000'
        option upload '10000'
        option qdisc 'fq_codel'
        option script 'simple.qos'
        option qdisc_advanced '0'
        option ingress_ecn 'ECN'
        option egress_ecn 'ECN'
        option qdisc_really_really_advanced '0'
        option itarget 'auto'
        option etarget 'auto'
        option linklayer 'none'
```

> Before
```
/etc/init.d/sqm restart
echo $?
1
```

> After
```
/etc/init.d/sqm restart
echo $?
0
```