### PR TITLE
Migrate OpenWrt init script to procd

### DIFF
--- a/platform/openwrt/sqm-init
+++ b/platform/openwrt/sqm-init
@@ -1,19 +1,31 @@
 #!/bin/sh /etc/rc.common
 
 START=50
+USE_PROCD=1
 
-start()
+service_triggers()
 {
-    /usr/lib/sqm/run.sh start "$@"
+	procd_add_reload_trigger "sqm"
 }
 
-stop()
+reload_service()
 {
-    /usr/lib/sqm/run.sh stop "$@"
+	stop "$@"
+	start "$@"
+}
+
+start_service()
+{
+	/usr/lib/sqm/run.sh start "$@"
+}
+
+stop_service()
+{
+	/usr/lib/sqm/run.sh stop "$@"
 }
 
 boot()
 {
-    export SQM_VERBOSITY_MIN=5 # Silence errors
-    /usr/lib/sqm/run.sh start
+	export SQM_VERBOSITY_MIN=5 # Silence errors
+	/usr/lib/sqm/run.sh start
 }


### PR DESCRIPTION
Convert the OpenWrt specific init script to procd in order to allow for
config apply behaviour consistent with other services.

After the change, running either
  `ubus call service event '{"type":"config.change","data":{"package":"sqm"}}'`
or
  `reload_config` after editing `/etc/config/sqm`
will cause procd to issue an `/etc/init.d/sqm reload` call which will be
translated to an explicit stop, followed by a start action using the
`reload_service` procedure.

This conversion is also needed by upcoming LuCI changes which will drop
the proprietary config tracking and replace it with generic procd reload
signal handling.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>