### PR TITLE
Fix OpenWrt start script boot action

### DIFF
--- a/platform/openwrt/sqm-init
+++ b/platform/openwrt/sqm-init
@@ -27,5 +27,5 @@ stop_service()
 boot()
 {
 	export SQM_VERBOSITY_MIN=5 # Silence errors
-	/usr/lib/sqm/run.sh start
+	start "$@"
 }


### PR DESCRIPTION
On OpenWrt, the init script `boot()` procedure is usually a simple wrapper
directly calling `start()` which, for a procd enabled initscripts, performs
extra calls like invoking `procd_open_service()`, `start_service()` and
`procd_close_service()`.

Due to the fact that we redeclare `boot()` to directly start SQM with
reduced verbosity, the procd service registration was bypassed and
subsequent config change events during normal system operations had no
effect until an extra `/etc/init.d/sqm start`, `/etc/init.d/sqm restart`
or `/etc/init.d/sqm reload` was performed on the cli.

Fix this problem by changing `boot()` to directly call into the normal
`start()` action after the verbosity variable has been set.

Fixes https://github.com/openwrt/luci/pull/1769#issuecomment-386803265
Fixes 295d417 ("Migrate OpenWrt init script to procd")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>