### PR TITLE
Allow to specify HTB burst by duration in ms required to send one burst of data

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -42,7 +42,7 @@
 # so allow to specify the permitted burst in the time domain (microseconds)
 # so the user has a feeling for the associated worst case latency cost
 # set to zero to use htb default butst of one MTU
-[ -z "$SHAPER_BURST_DUR_US" ] && SHAPER_BURST_DUR_US=3000
+[ -z "$SHAPER_BURST_DUR_US" ] && SHAPER_BURST_DUR_US=1000
 [ -z "$ISHAPER_BURST_DUR_US" ] && ISHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
 [ -z "$ESHAPER_BURST_DUR_US" ] && ESHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
 

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -40,12 +40,12 @@
 [ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 
 # HTB without a sufficiently large burst/cburst value is a bit CPU hungry
-# so allow to specify the permitted burst in the time domain (miiliseconds)
+# so allow to specify the permitted burst in the time domain (microseconds)
 # so the user has a feeling for the associated worst case latency cost
 # set to zero to use htb default butst of one MTU
-[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
-[ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
-[ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+[ -z "$SHAPER_BURST_DUR_US" ] && SHAPER_BURST_DUR_US=3000
+[ -z "$ISHAPER_BURST_DUR_US" ] && ISHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
+[ -z "$ESHAPER_BURST_DUR_US" ] && ESHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
 
 
 # Logging verbosity

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -40,6 +40,15 @@
 [ -z "$SHAPER_BURST" ] && SHAPER_BURST="1"
 [ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 
+# HTB without a sufficiently large burst/cburst value is a bit CPU hungry
+# so allow to specify the permitted burst in the time domain (miiliseconds)
+# so the user has a feeling for the associated worst case latency cost
+[ -z "$HTB_BURST_FUNCTION" ] && HTB_BURST_FUNCTION="by_duration"	# classic or by_duration
+[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=2
+[ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+[ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+
+
 # Logging verbosity
 VERBOSITY_SILENT=0
 VERBOSITY_ERROR=1

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -43,6 +43,7 @@
 # so allow to specify the permitted burst in the time domain (miiliseconds)
 # so the user has a feeling for the associated worst case latency cost
 # set to zero to use htb default butst of one MTU
+# Note this allows values down to 0.001 or microseconds
 [ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
 [ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
 [ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -37,14 +37,13 @@
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
-[ -z "$SHAPER_BURST" ] && SHAPER_BURST="1"
 [ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 
 # HTB without a sufficiently large burst/cburst value is a bit CPU hungry
 # so allow to specify the permitted burst in the time domain (miiliseconds)
 # so the user has a feeling for the associated worst case latency cost
-[ -z "$HTB_BURST_FUNCTION" ] && HTB_BURST_FUNCTION="by_duration"	# classic or by_duration
-[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=2
+# set to zero to use htb default butst of one MTU
+[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
 [ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
 [ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
 

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -43,7 +43,6 @@
 # so allow to specify the permitted burst in the time domain (miiliseconds)
 # so the user has a feeling for the associated worst case latency cost
 # set to zero to use htb default butst of one MTU
-# Note this allows values down to 0.001 or microseconds
 [ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
 [ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
 [ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -37,7 +37,6 @@
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
-[ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 
 # HTB without a sufficiently large burst/cburst value is a bit CPU hungry
 # so allow to specify the permitted burst in the time domain (microseconds)
@@ -46,6 +45,13 @@
 [ -z "$SHAPER_BURST_DUR_US" ] && SHAPER_BURST_DUR_US=3000
 [ -z "$ISHAPER_BURST_DUR_US" ] && ISHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
 [ -z "$ESHAPER_BURST_DUR_US" ] && ESHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
+
+# use the same logic for the calculation of htb's quantum
+# quantum controlls how many bytes htb tries to deque from the current tier
+# before switching tiers.
+[ -z "$SHAPER_QUANTUM_DUR_US" ] && SHAPER_QUANTUM_DUR_US=$SHAPER_BURST_DUR_US
+[ -z "$ISHAPER_QUANTUM_DUR_US" ] && ISHAPER_QUANTUM_DUR_US=$SHAPER_QUANTUM_DUR_US
+[ -z "$ESHAPER_QUANTUM_DUR_US" ] && ESHAPER_QUANTUM_DUR_US=$SHAPER_QUANTUM_DUR_US
 
 
 # Logging verbosity

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -228,6 +228,7 @@ verify_qdisc() {
         #cannot instantiate tbf without args
         tbf) 
     	    IFB_MTU=$( get_mtu $ifb )
+	    IFB_MTU=$(( ${IFB_MTU} + 14 )) # TBF's warning is confused, it says MTU but it checks MTU + 14
 	    args="limit 1 burst ${IFB_MTU} rate 1kbps" 
 	    ;;
     esac

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -384,7 +384,7 @@ get_burst() {
     local BURST=
     
     if [ -z "${SHAPER_BURST_US}" ] ; then
-	local SHAPER_BURST_US=3000	# the duration of the burst in microseconds
+	local SHAPER_BURST_US=1000	# the duration of the burst in microseconds
 	sqm_warn "get_burst (by duration): Defaulting to ${SHAPER_BURST_US} microseconds bursts."
     fi
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -210,6 +210,7 @@ verify_qdisc() {
     local ifb=TMP_IFB_4_SQM
     local root_string="root" # this works for most qdiscs
     local args=""
+    local IFB_MTU=1514
 
     if [ -n "$supported" ]; then
         local found=0
@@ -219,11 +220,16 @@ verify_qdisc() {
         [ "$found" -eq "1" ] || return 1
     fi
     create_ifb $ifb || return 1
+    
+    
     case $qdisc in
         #ingress is special
         ingress) root_string="" ;;
         #cannot instantiate tbf without args
-        tbf) args="limit 1 burst 1 rate 1kbps" ;;
+        tbf) 
+    	    IFB_MTU=$( get_mtu $ifb )
+	    args="limit 1 burst ${IFB_MTU} rate 1kbps" 
+	    ;;
     esac
 
     $TC qdisc replace dev $ifb $root_string $qdisc $args

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -379,6 +379,8 @@ get_burst() {
     local BANDWIDTH=$2 # note bandwidth is always given in kbps
     local SHAPER_BURST_US=$3
 
+    sqm_debug "get_burst: 1: ${1}, 2: ${2}, 3: ${3}"
+
     local BURST=
     
     if [ -z "${SHAPER_BURST_US}" ] ; then
@@ -414,12 +416,12 @@ get_htb_burst() {
     local BANDWIDTH=$2
     local DURATION_US=$3
 
+    sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
+
     if [ -z "${DURATION_US}" ] ; then
 	local DURATION_US=${SHAPER_BURST_DUR_US}	# the duration of the burst in microseconds
 	sqm_warn "get_htb_burst (by duration): Defaulting to ${SHAPER_BURST_DUR_US} microseconds."
-    fi
-    
-    sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
+    fi    
 
     if [ -n "${HTB_MTU}" -a "${DURATION_US}" -gt "0" ] ; then
     	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_US} )

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -433,12 +433,7 @@ get_burst() {
     MIN_BURST=$(( ${MIN_BURST} * 53 ))	# for MTU 1489 to 1536 this will result in MIN_BURST = 1749 Bytes
     
     # htb/tbf expect burst to be specified in bytes, while bandwidth is in kbps
-    #BURST=$(( ((${TARGET_BURST_MS} * ${BANDWIDTH} * 1000) / 8000) ))
-    
-    # to allow for TARGET_BURST_MS as fraction >= 0.001 or microseconds
-    local TMP_BURST_US=$( printf %.0f\\n "${TARGET_BURST_MS}e3" ) # this effectively does floor($TARGET_BURST_MS * 1000)
-    BURST=$(( ((${TMP_BURST_US} * ${BANDWIDTH}) / 8000) ))
-    
+    BURST=$(( ((${TARGET_BURST_MS} * ${BANDWIDTH} * 1000) / 8000)  ))
     
     if [ ${BURST} -lt ${MIN_BURST} ] ; then
 	BURST=${MIN_BURST}
@@ -459,10 +454,7 @@ get_htb_burst() {
     
     sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
 
-    # to allow fractional DURATION_MS down to 0.001
-    local DURATION_US=$( printf %.0f\\n "${DURATION_MS}e3" ) # this effectively does floor($DURATION_MS * 1000)
-
-    if [ -n "${HTB_MTU}" -a "${DURATION_US}" -gt "0" ] ; then
+    if [ -n "${HTB_MTU}" -a "${DURATION_MS}" -gt "0" ] ; then
     	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_MS} )
     fi
     

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -406,7 +406,7 @@ htb_quantum_step() {
 # note thst to get htb to report the configured burst/cburt one needs to issue the following command (for 
 # ifbpppoe-wan):
 #	tc -d class show dev ifb4pppoe-wan
-get_burst_by_duration() {
+get_burst() {
     local MTU=$1
     local BANDWIDTH=$2 # note bandwidth is always given in kbps
     local TARGET_BURST_MS=$3
@@ -415,7 +415,7 @@ get_burst_by_duration() {
     
     if [ -z "${TARGET_BURST_MS}" ] ; then
 	local TARGET_BURST_MS=3	# the duration of the burst in milliseconds
-	sqm_debug "Defaulting to ${TARGET_BURST_MS} milliseconds for htb's burst and cburst parameters"
+	sqm_debug "Defaulting to ${TARGET_BURST_MS} milliseconds bursts."
     fi
 
 
@@ -428,7 +428,7 @@ get_burst_by_duration() {
 	BURST=${MIN_BURST}
     fi
 
-    sqm_debug "get_burst_by_duration: BURST [Byte]: ${BURST}, BANDWIDTH [Kbps]: ${BANDWIDTH}, DURATION [ms]: ${TARGET_BURST_MS}"
+    sqm_debug "get_burst (by duration): BURST [Byte]: ${BURST}, BANDWIDTH [Kbps]: ${BANDWIDTH}, DURATION [ms]: ${TARGET_BURST_MS}"
     
     echo ${BURST}
 }
@@ -444,7 +444,7 @@ get_htb_burst() {
     sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
 
     if [ -n "${HTB_MTU}" -a "${DURATION_MS}" -gt "0" ] ; then
-    	BURST=$( get_burst_by_duration ${HTB_MTU} ${BANDWIDTH} ${DURATION_MS} )
+    	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_MS} )
     fi
     
     if [ -z "$BURST" ]; then

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -416,13 +416,13 @@ htb_quantum_step() {
 get_burst() {
     local MTU=$1
     local BANDWIDTH=$2 # note bandwidth is always given in kbps
-    local TARGET_BURST_MS=$3
+    local SHAPER_BURST_US=$3
 
     local BURST=
     
-    if [ -z "${TARGET_BURST_MS}" ] ; then
-	local TARGET_BURST_MS=3	# the duration of the burst in milliseconds
-	sqm_debug "get_burst (by duration): Defaulting to ${TARGET_BURST_MS} milliseconds bursts."
+    if [ -z "${SHAPER_BURST_US}" ] ; then
+	local SHAPER_BURST_US=3000	# the duration of the burst in milliseconds
+	sqm_debug "get_burst (by duration): Defaulting to ${SHAPER_BURST_US} microseconds bursts."
     fi
 
     # let's assume ATM/AAL5 to be the worst case encapsulation
@@ -433,7 +433,7 @@ get_burst() {
     MIN_BURST=$(( ${MIN_BURST} * 53 ))	# for MTU 1489 to 1536 this will result in MIN_BURST = 1749 Bytes
     
     # htb/tbf expect burst to be specified in bytes, while bandwidth is in kbps
-    BURST=$(( ((${TARGET_BURST_MS} * ${BANDWIDTH} * 1000) / 8000)  ))
+    BURST=$(( ((${SHAPER_BURST_US} * ${BANDWIDTH}) / 8000) ))
     
     if [ ${BURST} -lt ${MIN_BURST} ] ; then
 	BURST=${MIN_BURST}
@@ -450,12 +450,12 @@ get_burst() {
 get_htb_burst() {
     local HTB_MTU=$( get_mtu $1 )
     local BANDWIDTH=$2
-    local DURATION_MS=$3
+    local DURATION_US=$3
     
     sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
 
-    if [ -n "${HTB_MTU}" -a "${DURATION_MS}" -gt "0" ] ; then
-    	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_MS} )
+    if [ -n "${HTB_MTU}" -a "${DURATION_US}" -gt "0" ] ; then
+    	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_US} )
     fi
     
     if [ -z "$BURST" ]; then

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -386,7 +386,7 @@ get_burst() {
     sqm_debug "get_burst: 1: ${1}, 2: ${2}, 3: ${3}"
 
     if [ -z "${SHAPER_BURST_US}" ] ; then
-	local SHAPER_BURST_US=1000	# the duration of the burst in microseconds
+	SHAPER_BURST_US=1000	# the duration of the burst in microseconds
 	sqm_warn "get_burst (by duration): Defaulting to ${SHAPER_BURST_US} microseconds bursts."
     fi
 

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -53,7 +53,6 @@ start_sqm_section() {
     export IQDISC_OPTS=$(config_get "$section" iqdisc_opts)
     export EQDISC_OPTS=$(config_get "$section" eqdisc_opts)
     export TARGET=$(config_get "$section" target)
-    export HTB_QUANTUM_FUNCTION=$(config_get "$section" htb_quantum_function)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)
 

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -53,7 +53,6 @@ start_sqm_section() {
     export IQDISC_OPTS=$(config_get "$section" iqdisc_opts)
     export EQDISC_OPTS=$(config_get "$section" eqdisc_opts)
     export TARGET=$(config_get "$section" target)
-    export SHAPER_BURST=$(config_get "$section" shaper_burst)
     export HTB_QUANTUM_FUNCTION=$(config_get "$section" htb_quantum_function)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -106,7 +106,7 @@ egress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL ${ETARGET_BURST_DUR_MS}`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2> /dev/null
 
@@ -183,7 +183,7 @@ ingress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL ${ITARGET_BURST_DUR_MS}`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -105,7 +105,7 @@ egress() {
     BK_RATE=`expr $CEIL / 6`   # Min for background
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
-    LQ="quantum `get_htb_quantum $IFACE $CEIL`"
+    LQ="quantum `get_htb_quantum $IFACE $CEIL ${ESHAPER_QUANTUM_DUR_US}`"
     BURST="`get_htb_burst $IFACE $CEIL ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2> /dev/null
@@ -182,7 +182,7 @@ ingress() {
     BK_RATE=`expr $CEIL / 6`   # Min for background
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
-    LQ="quantum `get_htb_quantum $IFACE $CEIL`"
+    LQ="quantum `get_htb_quantum $IFACE $CEIL ${ISHAPER_QUANTUM_DUR_US}`"
     BURST="`get_htb_burst $IFACE $CEIL ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -106,7 +106,7 @@ egress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ETARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE root 2> /dev/null
 
@@ -183,7 +183,7 @@ ingress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ITARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -35,7 +35,7 @@ cake_egress()
 egress() {
 
     LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
-    BURST="`get_htb_burst $IFACE ${UPLINK} ${ETARGET_BURST_DUR_MS}`"
+    BURST="`get_htb_burst $IFACE ${UPLINK} ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2>/dev/null
 
@@ -68,7 +68,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
-    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ITARGET_BURST_DUR_MS}`"
+    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $DEV root 2>/dev/null
 

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -35,7 +35,7 @@ cake_egress()
 egress() {
 
     LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
-    BURST="`get_htb_burst $IFACE ${UPLINK}`"
+    BURST="`get_htb_burst $IFACE ${UPLINK} ${ETARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE root 2>/dev/null
 
@@ -68,7 +68,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
-    BURST="`get_htb_burst $IFACE ${DOWNLINK}`"
+    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ITARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $DEV root 2>/dev/null
 

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -34,7 +34,7 @@ cake_egress()
 
 egress() {
 
-    LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
+    LQ="quantum `get_htb_quantum $IFACE ${UPLINK} ${ESHAPER_QUANTUM_DUR_US}`"
     BURST="`get_htb_burst $IFACE ${UPLINK} ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -67,7 +67,7 @@ ingress() {
     $TC qdisc del dev $IFACE handle ffff: ingress 2>/dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress
 
-    LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
+    LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK} ${ISHAPER_QUANTUM_DUR_US}`"
     BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $DEV root 2>/dev/null

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ESHAPER_BURST_DUR_US})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ISHAPER_BURST_DUR_US})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${UPLINK})"
+    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK})"
+    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
+    BURST="$(get_burst_by_duration ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
+    BURST="$(get_burst_by_duration ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst_by_duration ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst_by_duration ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null


### PR DESCRIPTION
This should make it more obvious how much latency under load increase
htb's burst might cause (while probably allowing to use the configured
bandwidth fuller than HTB with the minimal burst). Currently this defaults to
a minimum of 2 MTUs and has no upper bound. The hope is that this makes it simpler to 
specify an acceptable burst parameter.
