### PR TITLE
Implement slightly more verbose error reporting from ip and tc

### DIFF
--- a/src/functions.sh
+++ b/src/functions.sh
@@ -72,13 +72,16 @@ ipt() {
 }
 
 
-# wrapper to call tc to allow debug logging
 tc_wrapper() {
+    local LAST_ERROR
+    local RET
+
     sqm_trace "${TC_BINARY} $*"
-    local LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
-    #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
-    echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
-    if [ -z "$LAST_ERROR" ] ; then
+    LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
+    RET=$?
+    sqm_trace "${LAST_ERROR}"
+
+    if [ "$RET" -eq "0" ] ; then
         sqm_debug "tc_wrapper: SUCCESS: ${TC_BINARY} $*"
     else
         # this went south, try to capture & report more detail
@@ -90,11 +93,15 @@ tc_wrapper() {
 
 # wrapper to call ip to allow debug logging
 ip_wrapper() {
+    local LAST_ERROR
+    local RET
+
     sqm_trace "${IP_BINARY} $*"
-    local LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
-    #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
-    echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
-    if [ -z "$LAST_ERROR" ] ; then
+    LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
+    RET=$?
+    sqm_trace "${LAST_ERROR}"
+
+    if [ "$RET" -eq "0" ] ; then
         sqm_debug "ip_wrapper: SUCCESS: ${IP_BINARY} $*"
     else
         # this went south, try to capture & report more detail

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -73,12 +73,12 @@ ipt() {
 
 # wrapper to call tc to allow debug logging
 tc_wrapper(){
-    cmd_wrapper tc ${TC_BINARY} $*
+    cmd_wrapper tc ${TC_BINARY} $@
 }
 
 # wrapper to call ip to allow debug logging
 ip_wrapper(){
-    cmd_wrapper ip ${IP_BINARY} $*
+    cmd_wrapper ip ${IP_BINARY} $@
 }
 
 # the actual command execution wrapper
@@ -94,16 +94,16 @@ cmd_wrapper(){
     CALLERID=$1 ; shift 1   # extract and remove the id string
     CMD_BINARY=$1 ; shift 1 # extract and remove the binary
 
-    sqm_trace "${CMD_BINARY} $*"
+    sqm_trace "${CMD_BINARY} $@"
     LAST_ERROR=$( ${CMD_BINARY} $* 2>&1 )
     RET=$?
     sqm_trace "${LAST_ERROR}"
 
     if [ "$RET" -eq "0" ] ; then
-        sqm_debug "cmd_wrapper: ${CALLERID}: SUCCESS: ${CMD_BINARY} $*"
+        sqm_debug "cmd_wrapper: ${CALLERID}: SUCCESS: ${CMD_BINARY} $@"
     else
         # this went south, try to capture & report more detail
-        sqm_error "cmd_wrapper: ${CALLERID}: FAILURE: ${CMD_BINARY} $*"
+        sqm_error "cmd_wrapper: ${CALLERID}: FAILURE: ${CMD_BINARY} $@"
         sqm_error "cmd_wrapper: ${CALLERID}: LAST ERROR: ${LAST_ERROR}"
     fi
 }

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -71,36 +71,33 @@ ipt() {
     ip6tables $* >> ${OUTPUT_TARGET} 2>&1
 }
 
+
 # wrapper to call tc to allow debug logging
 tc_wrapper() {
-    #tc_args=$*
     sqm_trace "${TC_BINARY} $*"
-    ${TC_BINARY} $* >> ${OUTPUT_TARGET} 2>&1
-
-    local res=$?
-    if [ "$res" = "0" ] ; then
+    local LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
+    #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
+    echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
+    if [ -z "$LAST_ERROR" ] ; then
         sqm_debug "tc_wraper: SUCCESS: ${TC_BINARY} $*"
     else
         # this went south, try to capture & report more detail
-        LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
         sqm_error "tc_wrapper: FAILURE: ${TC_BINARY} $*"
         sqm_error "tc_wrapper: LAST ERROR: ${LAST_ERROR}"
     fi
 }
-    
-    
+
+
 # wrapper to call ip to allow debug logging
 ip_wrapper() {
-    #ip_args=$*
     sqm_trace "${IP_BINARY} $*"
-    ${IP_BINARY} $* >> ${OUTPUT_TARGET} 2>&1
-    
-    local res=$?
-    if [ "$res" = "0" ] ; then
-        sqm_debug "ip_wrapper: SUCCESS: ${IP_BINARY} $*"
+    local LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
+    #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
+    echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
+    if [ -z "$LAST_ERROR" ] ; then
+        sqm_debug "ip_wraper: SUCCESS: ${IP_BINARY} $*"
     else
         # this went south, try to capture & report more detail
-        LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
         sqm_error "ip_wrapper: FAILURE: ${IP_BINARY} $*"
         sqm_error "ip_wrapper: LAST ERROR: ${LAST_ERROR}"
     fi

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -79,7 +79,7 @@ tc_wrapper() {
     #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
     echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
     if [ -z "$LAST_ERROR" ] ; then
-        sqm_debug "tc_wraper: SUCCESS: ${TC_BINARY} $*"
+        sqm_debug "tc_wrapper: SUCCESS: ${TC_BINARY} $*"
     else
         # this went south, try to capture & report more detail
         sqm_error "tc_wrapper: FAILURE: ${TC_BINARY} $*"
@@ -95,7 +95,7 @@ ip_wrapper() {
     #sqm_error "LAST_ERROR:: ${LAST_ERROR}"
     echo ${LAST_ERROR} >> ${OUTPUT_TARGET} 2>&1
     if [ -z "$LAST_ERROR" ] ; then
-        sqm_debug "ip_wraper: SUCCESS: ${IP_BINARY} $*"
+        sqm_debug "ip_wrapper: SUCCESS: ${IP_BINARY} $*"
     else
         # this went south, try to capture & report more detail
         sqm_error "ip_wrapper: FAILURE: ${IP_BINARY} $*"

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -71,42 +71,40 @@ ipt() {
     ip6tables $* >> ${OUTPUT_TARGET} 2>&1
 }
 
-
-tc_wrapper() {
-    local LAST_ERROR
-    local RET
-
-    sqm_trace "${TC_BINARY} $*"
-    LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
-    RET=$?
-    sqm_trace "${LAST_ERROR}"
-
-    if [ "$RET" -eq "0" ] ; then
-        sqm_debug "tc_wrapper: SUCCESS: ${TC_BINARY} $*"
-    else
-        # this went south, try to capture & report more detail
-        sqm_error "tc_wrapper: FAILURE: ${TC_BINARY} $*"
-        sqm_error "tc_wrapper: LAST ERROR: ${LAST_ERROR}"
-    fi
+# wrapper to call tc to allow debug logging
+tc_wrapper(){
+    cmd_wrapper tc ${TC_BINARY} $*
 }
 
-
 # wrapper to call ip to allow debug logging
-ip_wrapper() {
+ip_wrapper(){
+    cmd_wrapper ip ${IP_BINARY} $*
+}
+
+# the actual command execution wrapper
+cmd_wrapper(){
+    # $1: the symbolic name of the command for informative output
+    # $2: the name of the binary to call (potentially including the full path)
+    # $3-$end: the actual arguments for $2
+    local CALLERID
+    local CMD_BINARY
     local LAST_ERROR
     local RET
 
-    sqm_trace "${IP_BINARY} $*"
-    LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
+    CALLERID=$1 ; shift 1   # extract and remove the id string
+    CMD_BINARY=$1 ; shift 1 # extract and remove the binary
+
+    sqm_trace "${CMD_BINARY} $*"
+    LAST_ERROR=$( ${CMD_BINARY} $* 2>&1 )
     RET=$?
     sqm_trace "${LAST_ERROR}"
 
     if [ "$RET" -eq "0" ] ; then
-        sqm_debug "ip_wrapper: SUCCESS: ${IP_BINARY} $*"
+        sqm_debug "cmd_wrapper: ${CALLERID}: SUCCESS: ${CMD_BINARY} $*"
     else
         # this went south, try to capture & report more detail
-        sqm_error "ip_wrapper: FAILURE: ${IP_BINARY} $*"
-        sqm_error "ip_wrapper: LAST ERROR: ${LAST_ERROR}"
+        sqm_error "cmd_wrapper: ${CALLERID}: FAILURE: ${CMD_BINARY} $*"
+        sqm_error "cmd_wrapper: ${CALLERID}: LAST ERROR: ${LAST_ERROR}"
     fi
 }
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -22,7 +22,7 @@
 ################################################################################
 #
 # Hint to test functions from this file from the shell use:
-#	. /etc/sqm/sqm.conf ; . ${SQM_LIB_DIR}/defaults.sh ; . ${SQM_LIB_DIR}/functions.sh ; ${FUNCTIONNAME} ${ARGUMENTS}
+# . /etc/sqm/sqm.conf ; . ${SQM_LIB_DIR}/defaults.sh ; . ${SQM_LIB_DIR}/functions.sh ; ${FUNCTIONNAME} ${ARGUMENTS}
 #
 ################################################################################
 
@@ -82,12 +82,12 @@ ipt() {
 
 # wrapper to call tc to allow debug logging
 tc_wrapper(){
-    cmd_wrapper tc ${TC_BINARY} $@
+    cmd_wrapper tc ${TC_BINARY} "$@"
 }
 
 # wrapper to call ip to allow debug logging
 ip_wrapper(){
-    cmd_wrapper ip ${IP_BINARY} $@
+    cmd_wrapper ip ${IP_BINARY} "$@"
 }
 
 # the actual command execution wrapper
@@ -104,7 +104,7 @@ cmd_wrapper(){
     CMD_BINARY=$1 ; shift 1 # extract and remove the binary
 
     sqm_trace "${CMD_BINARY} $@"
-    LAST_ERROR=$( ${CMD_BINARY} $@ 2>&1 )
+    LAST_ERROR=$( ${CMD_BINARY} "$@" 2>&1 )
     RET=$?
     sqm_trace "${LAST_ERROR}"
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -73,16 +73,37 @@ ipt() {
 
 # wrapper to call tc to allow debug logging
 tc_wrapper() {
-    tc_args=$*
+    #tc_args=$*
     sqm_trace "${TC_BINARY} $*"
     ${TC_BINARY} $* >> ${OUTPUT_TARGET} 2>&1
-}
 
-# wrapper to call tc to allow debug logging
+    local res=$?
+    if [ "$res" = "0" ] ; then
+        sqm_debug "tc_wraper: SUCCESS: ${TC_BINARY} $*"
+    else
+        # this went south, try to capture & report more detail
+        LAST_ERROR=$( ${TC_BINARY} $* 2>&1 )
+        sqm_error "tc_wrapper: FAILURE: ${TC_BINARY} $*"
+        sqm_error "tc_wrapper: LAST ERROR: ${LAST_ERROR}"
+    fi
+}
+    
+    
+# wrapper to call ip to allow debug logging
 ip_wrapper() {
-    ip_args=$*
+    #ip_args=$*
     sqm_trace "${IP_BINARY} $*"
     ${IP_BINARY} $* >> ${OUTPUT_TARGET} 2>&1
+    
+    local res=$?
+    if [ "$res" = "0" ] ; then
+        sqm_debug "ip_wrapper: SUCCESS: ${IP_BINARY} $*"
+    else
+        # this went south, try to capture & report more detail
+        LAST_ERROR=$( ${IP_BINARY} $* 2>&1 )
+        sqm_error "ip_wrapper: FAILURE: ${IP_BINARY} $*"
+        sqm_error "ip_wrapper: LAST ERROR: ${LAST_ERROR}"
+    fi
 }
 
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -15,11 +15,20 @@
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
 #
-#   Copyright (C) 2012-6
+#   Copyright (C) 2012-8
 #       Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 #       Eric Luehrsen
 #
 ################################################################################
+#
+# Hint to test functions from this file from the shell use:
+#	. /etc/sqm/sqm.conf ; . ${SQM_LIB_DIR}/defaults.sh ; . ${SQM_LIB_DIR}/functions.sh ; ${FUNCTIONNAME} ${ARGUMENTS}
+#
+################################################################################
+
+
+
+
 
 sqm_logger() {
     case $1 in
@@ -95,7 +104,7 @@ cmd_wrapper(){
     CMD_BINARY=$1 ; shift 1 # extract and remove the binary
 
     sqm_trace "${CMD_BINARY} $@"
-    LAST_ERROR=$( ${CMD_BINARY} $* 2>&1 )
+    LAST_ERROR=$( ${CMD_BINARY} $@ 2>&1 )
     RET=$?
     sqm_trace "${LAST_ERROR}"
 


### PR DESCRIPTION
Hi Toke,

running with your idea of implementing better error reporting for calls to tc instead of 
hackishly trying to check tc argument validity from parsing tc help output.
The idea here is to check the exit status of tc and ip binary invocations, and
on error repeat the exact same call but redirect standard error into a shell
variable and sqm_error that variable, so the user gets a better idea what went
wrong. This sure beats silently failing.


This commit now monitors calls to the tc and ip binary from
inside [tc|ip]_wrapper function and will sqm_error with the
standard error returned from the offensive binary invocation.
This should make it easier to catch and correct bad arguments
passed to either tc or ip.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>