### PR TITLE
Burst by duration squashed

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -37,15 +37,21 @@
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
-[ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
 
 # HTB without a sufficiently large burst/cburst value is a bit CPU hungry
-# so allow to specify the permitted burst in the time domain (miiliseconds)
+# so allow to specify the permitted burst in the time domain (microseconds)
 # so the user has a feeling for the associated worst case latency cost
 # set to zero to use htb default butst of one MTU
-[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
-[ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
-[ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+[ -z "$SHAPER_BURST_DUR_US" ] && SHAPER_BURST_DUR_US=1000
+[ -z "$ISHAPER_BURST_DUR_US" ] && ISHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
+[ -z "$ESHAPER_BURST_DUR_US" ] && ESHAPER_BURST_DUR_US=$SHAPER_BURST_DUR_US
+
+# use the same logic for the calculation of htb's quantum
+# quantum controlls how many bytes htb tries to deque from the current tier
+# before switching tiers.
+[ -z "$SHAPER_QUANTUM_DUR_US" ] && SHAPER_QUANTUM_DUR_US=$SHAPER_BURST_DUR_US
+[ -z "$ISHAPER_QUANTUM_DUR_US" ] && ISHAPER_QUANTUM_DUR_US=$SHAPER_QUANTUM_DUR_US
+[ -z "$ESHAPER_QUANTUM_DUR_US" ] && ESHAPER_QUANTUM_DUR_US=$SHAPER_QUANTUM_DUR_US
 
 
 # Logging verbosity

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -37,8 +37,16 @@
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
-[ -z "$SHAPER_BURST" ] && SHAPER_BURST="1"
 [ -z "$HTB_QUANTUM_FUNCTION" ] && HTB_QUANTUM_FUNCTION="linear"
+
+# HTB without a sufficiently large burst/cburst value is a bit CPU hungry
+# so allow to specify the permitted burst in the time domain (miiliseconds)
+# so the user has a feeling for the associated worst case latency cost
+# set to zero to use htb default butst of one MTU
+[ -z "$TARGET_BURST_DUR_MS" ] && TARGET_BURST_DUR_MS=3
+[ -z "$ITARGET_BURST_DUR_MS" ] && ITARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+[ -z "$ETARGET_BURST_DUR_MS" ] && ETARGET_BURST_DUR_MS=$TARGET_BURST_DUR_MS
+
 
 # Logging verbosity
 VERBOSITY_SILENT=0

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -233,6 +233,7 @@ verify_qdisc() {
     local ifb=TMP_IFB_4_SQM
     local root_string="root" # this works for most qdiscs
     local args=""
+    local IFB_MTU=1514
 
     if [ -n "$supported" ]; then
         local found=0
@@ -242,11 +243,17 @@ verify_qdisc() {
         [ "$found" -eq "1" ] || return 1
     fi
     create_ifb $ifb || return 1
+    
+    
     case $qdisc in
         #ingress is special
         ingress) root_string="" ;;
         #cannot instantiate tbf without args
-        tbf) args="limit 1 burst 1 rate 1kbps" ;;
+        tbf) 
+    	    IFB_MTU=$( get_mtu $ifb )
+	    IFB_MTU=$(( ${IFB_MTU} + 14 )) # TBF's warning is confused, it says MTU but it checks MTU + 14
+	    args="limit 1 burst ${IFB_MTU} rate 1kbps" 
+	    ;;
     esac
 
     $TC qdisc replace dev $ifb $root_string $qdisc $args

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -349,115 +349,81 @@ fc() {
     prio=$(($prio + 1))
 }
 
-# Scale quantum with bandwidth to lower computation cost.
+
+# allow better control over HTB's quantum variable
+# this controlls how many bytes htb ties to deque from the current tier before 
+# switching to the next, if this is large mixing between pririty tiers will
+# be lumpy, but at a lower CPU cost. In first approximation quantum should not be 
+# larger than burst.
 get_htb_quantum() {
-    case "$HTB_QUANTUM_FUNCTION" in
-        linear|step)
-            eval "htb_quantum_${HTB_QUANTUM_FUNCTION} $1 $2" ;;
-        *)
-            sqm_warn "unknown HTB quantum function: '$HTB_QUANTUM_FUNCTION'."
-            echo 1500 ;; # fallback
-    esac
-}
+    local HTB_MTU=$( get_mtu $1 )
+    local BANDWIDTH=$2
+    local DURATION_US=$3
+    local MIN_QUANTUM
+    local QUANTUM
 
-# Linear scaling within bounds
-htb_quantum_linear() {
-    HTB_MTU=$( get_mtu $1 )
-    BANDWIDTH=$2
+    sqm_debug "get_htb_quantum: 1: ${1}, 2: ${2}, 3: ${3}"
 
-    if [ -z "${HTB_MTU}" ] ; then
-        HTB_MTU=1500
+    if [ -z "${DURATION_US}" ] ; then
+	DURATION_US=${SHAPER_QUANTUM_DUR_US}	# the duration of the burst in microseconds
+	sqm_warn "get_htb_quantum (by duration): Defaulting to ${DURATION_US} microseconds."
     fi
-
-    # Because $BANDWIDTH is in kbps, bytes/1ms is simply factor-8
-    # Stop at some huge quantum, and don't start until 2 MTU
-    BANDWIDTH_L=$(( ${HTB_MTU} *  2 * 8 ))
-    BANDWIDTH_H=$(( ${HTB_MTU} * 64 * 8 ))
-
-    if [ ${BANDWIDTH} -gt ${BANDWIDTH_H} ] ; then
-        HTB_QUANTUM=$(( ${HTB_MTU} * 64 ))
-
-    elif [ ${BANDWIDTH} -gt ${BANDWIDTH_L} ] ; then
-        # Take no chances with order o' exec rounding
-        HTB_QUANTUM=$(( ${BANDWIDTH}   / 8 ))
-        HTB_QUANTUM=$(( ${HTB_QUANTUM} / ${HTB_MTU} ))
-        HTB_QUANTUM=$(( ${HTB_QUANTUM} * ${HTB_MTU} ))
-
+    
+    if [ -n "${HTB_MTU}" -a "${DURATION_US}" -gt "0" ] ; then
+    	QUANTUM=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_US} )
+    fi
+    
+    if [ -z "$QUANTUM" ]; then
+	MIN_QUANTUM=$(( ${MTU} + 48 ))	# add 48 bytes to MTU for the  ovehead
+	MIN_QUANTUM=$(( ${MIN_QUANTUM} + 47 ))	# now do ceil(Min_BURST / 48) * 53 in shell integer arithmic
+	MIN_QUANTUM=$(( ${MIN_QUANTUM} / 48 ))
+	MIN_QUANTUM=$(( ${MIN_QUANTUM} * 53 ))	# for MTU 1489 to 1536 this will result in MIN_BURST = 1749 Bytes
+	sqm_warn "get_htb_quantum: 0 bytes quantum will not work, defaulting to one ATM/AAL5 expanded MTU packet with overhead: ${MIN_QUANTUM}"
+	echo ${MIN_QUANTUM}
     else
-        HTB_QUANTUM=${HTB_MTU}
+        echo ${QUANTUM}
     fi
-
-    sqm_debug "HTB_QUANTUM (linear): ${HTB_QUANTUM}, BANDWIDTH: ${BANDWIDTH}"
-
-    echo $HTB_QUANTUM
 }
 
-# Fixed step scaling
-htb_quantum_step() {
-    HTB_QUANTUM=$( get_mtu $1 )
-    BANDWIDTH=$2
 
-    if [ -z "${HTB_QUANTUM}" ]; then
-        HTB_QUANTUM=1500
-    fi
-    if [ ${BANDWIDTH} -gt 20000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-    if [ ${BANDWIDTH} -gt 30000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-    if [ ${BANDWIDTH} -gt 40000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-    if [ ${BANDWIDTH} -gt 50000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-    if [ ${BANDWIDTH} -gt 60000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-    if [ ${BANDWIDTH} -gt 80000 ]; then
-        HTB_QUANTUM=$((${HTB_QUANTUM} * 2))
-    fi
-
-    sqm_debug "HTB_QUANTUM (step): ${HTB_QUANTUM}, BANDWIDTH: ${BANDWIDTH}"
-
-    echo $HTB_QUANTUM
-}
 
 
 # try to define the burst parameter in the duration required to transmit a burst at the configured bandwidth
 # conceptuallly the matching quantum for this burst should be BURST/number_of_tiers to give each htb tier a 
 # chance to dequeue into each burst, but that most likely will end up with a somewhat too small quantum
-# note thst to get htb to report the configured burst/cburt one needs to issue the following command (for 
+# note: to get htb to report the configured burst/cburt one needs to issue the following command (for 
 # ifbpppoe-wan):
 #	tc -d class show dev ifb4pppoe-wan
 get_burst() {
     local MTU=$1
     local BANDWIDTH=$2 # note bandwidth is always given in kbps
-    local TARGET_BURST_MS=$3
+    local SHAPER_BURST_US=$3
+    local MIN_BURST
+    local BURST
 
-    local BURST=
-    
-    if [ -z "${TARGET_BURST_MS}" ] ; then
-	local TARGET_BURST_MS=3	# the duration of the burst in milliseconds
-	sqm_debug "get_burst (by duration): Defaulting to ${TARGET_BURST_MS} milliseconds bursts."
+    sqm_debug "get_burst: 1: ${1}, 2: ${2}, 3: ${3}"
+
+    if [ -z "${SHAPER_BURST_US}" ] ; then
+	SHAPER_BURST_US=1000	# the duration of the burst in microseconds
+	sqm_warn "get_burst (by duration): Defaulting to ${SHAPER_BURST_US} microseconds bursts."
     fi
 
     # let's assume ATM/AAL5 to be the worst case encapsulation
     #	and 48 Bytes a reasonable worst case per packet overhead
-    local MIN_BURST=$(( ${MTU} + 48 ))	# add 48 bytes to MTU for the  ovehead
+    MIN_BURST=$(( ${MTU} + 48 ))	# add 48 bytes to MTU for the  ovehead
     MIN_BURST=$(( ${MIN_BURST} + 47 ))	# now do ceil(Min_BURST / 48) * 53 in shell integer arithmic
     MIN_BURST=$(( ${MIN_BURST} / 48 ))
     MIN_BURST=$(( ${MIN_BURST} * 53 ))	# for MTU 1489 to 1536 this will result in MIN_BURST = 1749 Bytes
     
     # htb/tbf expect burst to be specified in bytes, while bandwidth is in kbps
-    BURST=$(( ((${TARGET_BURST_MS} * ${BANDWIDTH} * 1000) / 8000)  ))
+    BURST=$(( ((${SHAPER_BURST_US} * ${BANDWIDTH}) / 8000) ))
     
     if [ ${BURST} -lt ${MIN_BURST} ] ; then
+	sqm_log "get_burst (by duration): the calculated burst/quantum size of ${BURST} bytes was below the minimum of ${MIN_BURST} bytes."
 	BURST=${MIN_BURST}
     fi
 
-    sqm_debug "get_burst (by duration): BURST [Byte]: ${BURST}, BANDWIDTH [Kbps]: ${BANDWIDTH}, DURATION [ms]: ${TARGET_BURST_MS}"
+    sqm_debug "get_burst (by duration): BURST [Byte]: ${BURST}, BANDWIDTH [Kbps]: ${BANDWIDTH}, DURATION [us]: ${SHAPER_BURST_US}"
     
     echo ${BURST}
 }
@@ -468,14 +434,20 @@ get_burst() {
 get_htb_burst() {
     local HTB_MTU=$( get_mtu $1 )
     local BANDWIDTH=$2
-    local DURATION_MS=$3
-    
+    local DURATION_US=$3
+    local BURST
+
     sqm_debug "get_htb_burst: 1: ${1}, 2: ${2}, 3: ${3}"
 
-    if [ -n "${HTB_MTU}" -a "${DURATION_MS}" -gt "0" ] ; then
-    	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_MS} )
+    if [ -z "${DURATION_US}" ] ; then
+	DURATION_US=${SHAPER_BURST_DUR_US}	# the duration of the burst in microseconds
+	sqm_warn "get_htb_burst (by duration): Defaulting to ${SHAPER_BURST_DUR_US} microseconds."
     fi
-    
+
+    if [ -n "${HTB_MTU}" -a "${DURATION_US}" -gt "0" ] ; then
+    	BURST=$( get_burst ${HTB_MTU} ${BANDWIDTH} ${DURATION_US} )
+    fi
+
     if [ -z "$BURST" ]; then
 	sqm_debug "get_htb_burst: Default Burst, HTB will use MTU plus shipping and handling"
     else

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -53,7 +53,6 @@ start_sqm_section() {
     export IQDISC_OPTS=$(config_get "$section" iqdisc_opts)
     export EQDISC_OPTS=$(config_get "$section" eqdisc_opts)
     export TARGET=$(config_get "$section" target)
-    export HTB_QUANTUM_FUNCTION=$(config_get "$section" htb_quantum_function)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)
 

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -53,7 +53,6 @@ start_sqm_section() {
     export IQDISC_OPTS=$(config_get "$section" iqdisc_opts)
     export EQDISC_OPTS=$(config_get "$section" eqdisc_opts)
     export TARGET=$(config_get "$section" target)
-    export SHAPER_BURST=$(config_get "$section" shaper_burst)
     export HTB_QUANTUM_FUNCTION=$(config_get "$section" htb_quantum_function)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -105,8 +105,8 @@ egress() {
     BK_RATE=`expr $CEIL / 6`   # Min for background
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
-    LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL ${ETARGET_BURST_DUR_MS}`"
+    LQ="quantum `get_htb_quantum $IFACE $CEIL ${ESHAPER_QUANTUM_DUR_US}`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2> /dev/null
 
@@ -182,8 +182,8 @@ ingress() {
     BK_RATE=`expr $CEIL / 6`   # Min for background
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
-    LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL ${ITARGET_BURST_DUR_MS}`"
+    LQ="quantum `get_htb_quantum $IFACE $CEIL ${ISHAPER_QUANTUM_DUR_US}`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -106,7 +106,7 @@ egress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ETARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE root 2> /dev/null
 
@@ -183,7 +183,7 @@ ingress() {
     BE_CEIL=`expr $CEIL - 16`  # A little slop at the top
 
     LQ="quantum `get_htb_quantum $IFACE $CEIL`"
-    BURST="`get_htb_burst $IFACE $CEIL`"
+    BURST="`get_htb_burst $IFACE $CEIL ${ITARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE handle ffff: ingress 2> /dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -35,7 +35,7 @@ cake_egress()
 egress() {
 
     LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
-    BURST="`get_htb_burst $IFACE ${UPLINK}`"
+    BURST="`get_htb_burst $IFACE ${UPLINK} ${ETARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $IFACE root 2>/dev/null
 
@@ -68,7 +68,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
-    BURST="`get_htb_burst $IFACE ${DOWNLINK}`"
+    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ITARGET_BURST_DUR_MS}`"
 
     $TC qdisc del dev $DEV root 2>/dev/null
 

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -34,8 +34,8 @@ cake_egress()
 
 egress() {
 
-    LQ="quantum `get_htb_quantum $IFACE ${UPLINK}`"
-    BURST="`get_htb_burst $IFACE ${UPLINK} ${ETARGET_BURST_DUR_MS}`"
+    LQ="quantum `get_htb_quantum $IFACE ${UPLINK} ${ESHAPER_QUANTUM_DUR_US}`"
+    BURST="`get_htb_burst $IFACE ${UPLINK} ${ESHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $IFACE root 2>/dev/null
 
@@ -67,8 +67,8 @@ ingress() {
     $TC qdisc del dev $IFACE handle ffff: ingress 2>/dev/null
     $TC qdisc add dev $IFACE handle ffff: ingress
 
-    LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK}`"
-    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ITARGET_BURST_DUR_MS}`"
+    LQ="quantum `get_htb_quantum $IFACE ${DOWNLINK} ${ISHAPER_QUANTUM_DUR_US}`"
+    BURST="`get_htb_burst $IFACE ${DOWNLINK} ${ISHAPER_BURST_DUR_US}`"
 
     $TC qdisc del dev $DEV root 2>/dev/null
 

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ESHAPER_BURST_DUR_US})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
+    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ISHAPER_BURST_DUR_US})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -33,7 +33,7 @@
 egress() {
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${UPLINK})"
+    BURST="$(get_burst ${MTU:-1514} ${UPLINK} ${ETARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $IFACE root 2>/dev/null
@@ -52,7 +52,7 @@ ingress() {
     $TC qdisc add dev $IFACE handle ffff: ingress
 
     MTU=$(get_mtu $IFACE)
-    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK})"
+    BURST="$(get_burst ${MTU:-1514} ${DOWNLINK} ${ITARGET_BURST_DUR_MS})"
     BURST=${BURST:-1514}
 
     $TC qdisc del dev $DEV root 2>/dev/null


### PR DESCRIPTION
So here is an attempt to tidy up the burst_by_duration PR, by offering a slightly less messy version with fewer commits.
@tohojo please let me know whether that helps at all, or whether you would prefer the original PR?