### PR TITLE
Start sqm refinements

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -38,6 +38,9 @@
 [ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
 [ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
 
+[ -z "$CUR_DIRECTION" ] && CUR_DIRECTION="NONE"
+
+
 # HTB without a sufficiently large burst/cburst value is a bit CPU hungry
 # so allow to specify the permitted burst in the time domain (microseconds)
 # so the user has a feeling for the associated worst case latency cost

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -48,6 +48,11 @@ sqm_log() { sqm_logger $VERBOSITY_INFO "$@"; }
 sqm_debug() { sqm_logger $VERBOSITY_DEBUG "$@"; }
 sqm_trace() { sqm_logger $VERBOSITY_TRACE "$@"; }
 
+
+# from https://stackoverflow.com/questions/85880/determine-if-a-function-exists-in-bash
+fn_exists() { LC_ALL=C type $1 | grep -q 'is a function'; }
+
+
 # ipt needs a toggle to show the outputs for debugging (as do all users of >
 # /dev/null 2>&1 and friends)
 ipt() {
@@ -318,6 +323,47 @@ get_cake_lla_string() {
         sqm_debug "cake link layer adjustments: ${STABSTRING}"
     fi
     echo ${STABSTRING}
+}
+
+
+# centralize the implementation for the default sqm_start sqeuence
+# the individual sqm_start function only need to do the individually
+# necessary checking.
+# This expects the calling script to supply both an egress() and ingress() function
+# and will warn if they are missing
+sqm_start_default() {
+    #sqm_error "sqm_start_default"
+    [ -n "$IFACE" ] || return 1
+    #do_modules
+    #verify_qdisc $QDISC "cake" || return 1
+    sqm_debug "Starting ${SCRIPT}"
+
+    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
+
+    if [ "${UPLINK}" -ne 0 ];
+    then
+	CUR_DIRECTION="egress"
+	fn_exists egress && egress || sqm_warn "${SCRIPT} lacks an egress() function"
+        #egress
+        sqm_debug "egress shaping activated"
+    else
+        sqm_debug "egress shaping deactivated"
+        SILENT=1 $TC qdisc del dev ${IFACE} root
+    fi
+    if [ "${DOWNLINK}" -ne 0 ];
+    then
+	CUR_DIRECTION="ingress"
+	verify_qdisc ingress "ingress" || return 1
+	fn_exists ingress && ingress || sqm_warn "${SCRIPT} lacks an ingress() function"
+        #ingress
+        sqm_debug "ingress shaping activated"
+    else
+        sqm_debug "ingress shaping deactivated"
+        SILENT=1 $TC qdisc del dev ${DEV} root
+        SILENT=1 $TC qdisc del dev ${IFACE} ingress
+    fi
+
+    return 0
 }
 
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -338,34 +338,36 @@ sqm_start_default() {
     fn_exists sqm_prepare_script
     if [ "$?" -eq "0" ]; then
         sqm_prepare_script
+    else
+	sqm_debug "sqm_start_default: no sqm_prepare_script function found, proceeding without."
     fi
     
     
     do_modules
     verify_qdisc $QDISC || return 1
-    sqm_debug "Starting ${SCRIPT}"
+    sqm_debug "sqm_start_default: Starting ${SCRIPT}"
 
     [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
 
     if [ "${UPLINK}" -ne 0 ];
     then
 	CUR_DIRECTION="egress"
-	fn_exists egress && egress || sqm_warn "${SCRIPT} lacks an egress() function"
+	fn_exists egress && egress || sqm_warn "sqm_start_default: ${SCRIPT} lacks an egress() function"
         #egress
-        sqm_debug "egress shaping activated"
+        sqm_debug "sqm_start_default: egress shaping activated"
     else
-        sqm_debug "egress shaping deactivated"
+        sqm_debug "sqm_start_default: egress shaping deactivated"
         SILENT=1 $TC qdisc del dev ${IFACE} root
     fi
     if [ "${DOWNLINK}" -ne 0 ];
     then
 	CUR_DIRECTION="ingress"
 	verify_qdisc ingress "ingress" || return 1
-	fn_exists ingress && ingress || sqm_warn "${SCRIPT} lacks an ingress() function"
+	fn_exists ingress && ingress || sqm_warn "sqm_start_default: ${SCRIPT} lacks an ingress() function"
         #ingress
-        sqm_debug "ingress shaping activated"
+        sqm_debug "sqm_start_default: ingress shaping activated"
     else
-        sqm_debug "ingress shaping deactivated"
+        sqm_debug "sqm_start_default: ingress shaping deactivated"
         SILENT=1 $TC qdisc del dev ${DEV} root
         SILENT=1 $TC qdisc del dev ${IFACE} ingress
     fi

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -334,8 +334,15 @@ get_cake_lla_string() {
 sqm_start_default() {
     #sqm_error "sqm_start_default"
     [ -n "$IFACE" ] || return 1
-    #do_modules
-    #verify_qdisc $QDISC "cake" || return 1
+    
+    fn_exists sqm_prepare_script
+    if [ "$?" -eq "0" ]; then
+        sqm_prepare_script
+    fi
+    
+    
+    do_modules
+    verify_qdisc $QDISC || return 1
     sqm_debug "Starting ${SCRIPT}"
 
     [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -48,31 +48,7 @@ ingress() {
 }
 
 sqm_start() {
-    [ -n "$IFACE" ] || return 1
     do_modules
     verify_qdisc $QDISC "cake" || return 1
-    sqm_debug "Starting ${SCRIPT}"
-
-    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
-
-    if [ "${UPLINK}" -ne 0 ];
-    then
-        egress
-        sqm_debug "egress shaping activated"
-    else
-        sqm_debug "egress shaping deactivated"
-        SILENT=1 $TC qdisc del dev ${IFACE} root
-    fi
-    if [ "${DOWNLINK}" -ne 0 ];
-    then
-	verify_qdisc ingress "ingress" || return 1
-        ingress
-        sqm_debug "ingress shaping activated"
-    else
-        sqm_debug "ingress shaping deactivated"
-        SILENT=1 $TC qdisc del dev ${DEV} root
-        SILENT=1 $TC qdisc del dev ${IFACE} ingress
-    fi
-
-    return 0
+    sqm_start_default
 }

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -47,8 +47,7 @@ ingress() {
 	match u32 0 0 flowid 1:1 action mirred egress redirect dev $DEV
 }
 
-sqm_start() {
+sqm_prepare_script() {
     do_modules
     verify_qdisc $QDISC "cake" || return 1
-    sqm_start_default
 }

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -47,8 +47,7 @@ ingress() {
 	match u32 0 0 flowid 1:1 action mirred egress redirect dev $DEV
 }
 
-sqm_start() {
+sqm_prepare_script() {
     do_modules
     verify_qdisc $QDISC "cake" || return 1
-    sqm_start_default
 }

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -48,30 +48,7 @@ ingress() {
 }
 
 sqm_start() {
-    [ -n "$IFACE" ] || return 1
     do_modules
     verify_qdisc $QDISC "cake" || return 1
-    sqm_debug "Starting ${SCRIPT}"
-
-    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
-
-    if [ "${UPLINK}" -ne 0 ];
-    then
-        egress
-        sqm_debug "egress shaping activated"
-    else
-        sqm_debug "egress shaping deactivated"
-        SILENT=1 $TC qdisc del dev ${IFACE} root
-    fi
-    if [ "${DOWNLINK}" -ne 0 ];
-    then
-	verify_qdisc ingress "ingress" || return 1
-        ingress
-        sqm_debug "ingress shaping activated"
-    else
-        sqm_debug "ingress shaping deactivated"
-        SILENT=1 $TC qdisc del dev ${DEV} root
-        SILENT=1 $TC qdisc del dev ${IFACE} ingress
-    fi
-    return 0
+    sqm_start_default
 }

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -228,10 +228,8 @@ ingress() {
 
 }
 
-sqm_start() {
+sqm_prepare_script() {
     do_modules
     verify_qdisc "htb" || return 1
-    verify_qdisc $QDISC || return 1
     ipt_setup
-    sqm_start_default
 }

--- a/src/simple.qos
+++ b/src/simple.qos
@@ -229,34 +229,9 @@ ingress() {
 }
 
 sqm_start() {
-    [ -n "$IFACE" ] || return 1
     do_modules
     verify_qdisc "htb" || return 1
     verify_qdisc $QDISC || return 1
-    sqm_debug "Starting ${SCRIPT}"
-
-    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
-
     ipt_setup
-
-    if [ "$UPLINK" -ne 0 ]; then
-        egress
-        sqm_debug "egress shaping activated"
-    else
-        sqm_debug "egress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $IFACE root
-    fi
-
-    if [ "$DOWNLINK" -ne 0 ]; then
-        verify_qdisc ingress "ingress" || return 1
-        ingress
-        sqm_debug "ingress shaping activated"
-    else
-        sqm_debug "ingress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $DEV root
-        SILENT=1 $TC qdisc del dev $IFACE ingress
-    fi
-
-
-    return 0
+    sqm_start_default
 }

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -98,33 +98,10 @@ ingress() {
 }
 
 sqm_start() {
-    [ -n "$IFACE" ] || return 1
     do_modules
     verify_qdisc "htb" || return 1
     verify_qdisc $QDISC || return 1
-    sqm_debug "Starting ${SCRIPT}"
-
-    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
-
-
-    if [ "$UPLINK" -ne 0 ]; then
-        egress
-        sqm_debug "egress shaping activated"
-    else
-        sqm_debug "egress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $IFACE root
-    fi
-    if [ "$DOWNLINK" -ne 0 ]; then
-        verify_qdisc ingress "ingress" || return 1
-        ingress
-        sqm_debug "ingress shaping activated"
-    else
-        sqm_debug "ingress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $DEV root
-        SILENT=1 $TC qdisc del dev $IFACE ingress
-    fi
-
-    return 0
+    sqm_start_default
 }
 
 ################################################################################

--- a/src/simplest.qos
+++ b/src/simplest.qos
@@ -97,11 +97,9 @@ ingress() {
 
 }
 
-sqm_start() {
+sqm_prepare_script() {
     do_modules
     verify_qdisc "htb" || return 1
-    verify_qdisc $QDISC || return 1
-    sqm_start_default
 }
 
 ################################################################################

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -73,7 +73,6 @@ ingress() {
 }
 
 sqm_start() {
-    [ -n "$IFACE" ] || return 1
     do_modules
     verify_qdisc "tbf" || return 1
 
@@ -84,29 +83,7 @@ sqm_start() {
     esac
 
     verify_qdisc $QDISC || return 1
-    sqm_debug "Starting ${SCRIPT}"
-
-    [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )
-
-
-    if [ "$UPLINK" -ne 0 ]; then
-        egress
-        sqm_debug "egress shaping activated"
-    else
-        sqm_debug "egress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $IFACE root
-    fi
-    if [ "$DOWNLINK" -ne 0 ]; then
-        verify_qdisc ingress "ingress" || return 1
-        ingress
-        sqm_debug "ingress shaping activated"
-    else
-        sqm_debug "ingress shaping deactivated"
-        SILENT=1 $TC qdisc del dev $DEV root
-        SILENT=1 $TC qdisc del dev $IFACE ingress
-    fi
-
-    return 0
+    sqm_start_default
 }
 
 ################################################################################

--- a/src/simplest_tbf.qos
+++ b/src/simplest_tbf.qos
@@ -72,7 +72,7 @@ ingress() {
 
 }
 
-sqm_start() {
+sqm_prepare_script() {
     do_modules
     verify_qdisc "tbf" || return 1
 
@@ -81,9 +81,6 @@ sqm_start() {
             sqm_warn "Cake is not supported with this script; falling back to FQ-CoDel"
             QDISC=fq_codel ;;
     esac
-
-    verify_qdisc $QDISC || return 1
-    sqm_start_default
 }
 
 ################################################################################

--- a/src/start-sqm
+++ b/src/start-sqm
@@ -45,14 +45,16 @@ fi
 
 . "${SQM_LIB_DIR}/$SCRIPT"
 
-fn_exists sqm_start 
-if [ "$?" -ne "0" ]; then
-    sqm_error "${SCRIPT} lacks an sqm_start() function, exiting unsuccessfully; SQM was not started."
-    exit 1
-fi
-
 sqm_trace; sqm_trace "$(date): Starting." # Add some space and a date stamp to verbose log output and log files to separate runs
 sqm_log "Starting SQM script: ${SCRIPT} on ${IFACE}, in: ${DOWNLINK} Kbps, out: ${UPLINK} Kbps"
-sqm_start && write_defaults_vars_to_state_file ${STATE_FILE} ${SQM_LIB_DIR}/defaults.sh && sqm_log "${SCRIPT} was started on ${IFACE} successfully"
+
+fn_exists sqm_start 
+if [ "$?" -ne "0" ]; then
+    sqm_log "Using generic sqm_start_default function."
+    sqm_start_default && write_defaults_vars_to_state_file ${STATE_FILE} ${SQM_LIB_DIR}/defaults.sh && sqm_log "${SCRIPT} was started on ${IFACE} successfully"
+else
+    sqm_log "Using script specific sqm_start function overriding the generic sqm_start_default."
+    sqm_start && write_defaults_vars_to_state_file ${STATE_FILE} ${SQM_LIB_DIR}/defaults.sh && sqm_log "${SCRIPT} was started on ${IFACE} successfully"
+fi
 
 exit 0

--- a/src/start-sqm
+++ b/src/start-sqm
@@ -45,6 +45,12 @@ fi
 
 . "${SQM_LIB_DIR}/$SCRIPT"
 
+fn_exists sqm_start 
+if [ "$?" -ne "0" ]; then
+    sqm_error "${SCRIPT} lacks an sqm_start() function, exiting unsuccessfully; SQM was not started."
+    exit 1
+fi
+
 sqm_trace; sqm_trace "$(date): Starting." # Add some space and a date stamp to verbose log output and log files to separate runs
 sqm_log "Starting SQM script: ${SCRIPT} on ${IFACE}, in: ${DOWNLINK} Kbps, out: ${UPLINK} Kbps"
 sqm_start && write_defaults_vars_to_state_file ${STATE_FILE} ${SQM_LIB_DIR}/defaults.sh && sqm_log "${SCRIPT} was started on ${IFACE} successfully"


### PR DESCRIPTION
Okay, I believe this is now a reasonable pull request with a corrected branch name. The idea is to reduce the unnecessary replication of the start_sqm function in all .qos scripts, but retains the ability to over-ride the implicit new call to sqm_start_default(), by simply supplying a sqm_start() function inside a .qos script. The sqm_start_default() will attempt to call sqm_start_default(), egress(), and ingress(), if any function is missing this will be logged but the script execution should continue. This uses a type and grep based function fn_exists() to check whether the stated names above are functions in the current shell context.