### PR TITLE
[RFC]: Logging changes

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -29,6 +29,12 @@
 [ -z "$TC_BINARY" ] && TC_BINARY=$(which tc)
 [ -z "$IP" ] && IP=ip_wrapper
 [ -z "$IP_BINARY" ] && IP_BINARY=$(which ip)
+
+[ -z "$IPTABLES" ] && IPTABLES=iptables_wrapper
+[ -z "$IPTABLES_BINARY" ] && IPTABLES_BINARY=$(which iptables)
+[ -z "$IP6TABLES" ] && IP6TABLES=ip6tables_wrapper
+[ -z "$IP6TABLES_BINARY" ] && IP6TABLES_BINARY=$(which ip6tables)
+
 # Try modprobe first, fall back to insmod
 [ -z "$INSMOD" ] && INSMOD=$(which modprobe) || INSMOD=$(which insmod)
 [ -z "$TARGET" ] && TARGET="5ms"
@@ -69,11 +75,17 @@ VERBOSITY_TRACE=10
 [ -z "$SQM_VERBOSITY_MIN" ] && SQM_VERBOSITY_MIN=$VERBOSITY_SILENT
 
 [ -z "$SQM_DEBUG" ] && SQM_DEBUG=0
+# common logging from run.sh
+SQM_DEBUG_LOG=${SQM_STATE_DIR}/${IFACE}.debug.log
+# logging for the start-sqm script
+SQM_START_LOG=${SQM_STATE_DIR}/${IFACE}.start-sqm.log
+# logging for the stop-sqm script
+SQM_STOP_LOG=${SQM_STATE_DIR}/${IFACE}.stop-sqm.log
 if [ "$SQM_DEBUG" -eq "1" ]
 then
-    SQM_DEBUG_LOG=${SQM_STATE_DIR}/${IFACE}.debug.log
-    OUTPUT_TARGET=${SQM_DEBUG_LOG}
+    [ -z "${OUTPUT_TARGET}" ] && OUTPUT_TARGET=${SQM_DEBUG_LOG}
 else
+    [ -z "${OUTPUT_TARGET}" ] && 
     OUTPUT_TARGET="/dev/null"
 fi
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -89,7 +89,7 @@ fn_exists() {
 
 # ipt needs a toggle to show the outputs for debugging (as do all users of >
 # /dev/null 2>&1 and friends)
-ipt() {
+ipt_old() {
     d=$(echo $* | sed s/-A/-D/g)
     [ "$d" != "$*" ] && {
         sqm_trace "iptables ${d}"
@@ -110,18 +110,19 @@ ipt() {
     ip6tables $* >> ${OUTPUT_TARGET} 2>&1
 }
 
-ipt_new() {
+ipt() {
     d=$(echo $* | sed s/-A/-D/g)
     [ "$d" != "$*" ] && {
         ${IPTABLES} $d
-        sqm_trace "ip6tables ${d}"
         ${IP6TABLES} $d
     }
+
     d=$(echo $* | sed s/-I/-D/g)
     [ "$d" != "$*" ] && {
         ${IPTABLES} $d
         ${IP6TABLES} $d
     }
+
     ${IPTABLES} $*
     ${IP6TABLES} $*
 }

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -113,14 +113,14 @@ ipt_old() {
 ipt() {
     d=$(echo $* | sed s/-A/-D/g)
     [ "$d" != "$*" ] && {
-        ${IPTABLES} $d
-        ${IP6TABLES} $d
+        SILENT=1 ${IPTABLES} $d
+        SILENT=1 ${IP6TABLES} $d
     }
 
     d=$(echo $* | sed s/-I/-D/g)
     [ "$d" != "$*" ] && {
-        ${IPTABLES} $d
-        ${IP6TABLES} $d
+        SILENT=1 ${IPTABLES} $d
+        SILENT=1 ${IP6TABLES} $d
     }
 
     ${IPTABLES} $*

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -40,6 +40,15 @@ sqm_logger() {
             echo "$@" >> ${SQM_DEBUG_LOG}
         fi
     fi
+    #echo "OUTPUT_TARGET: ${OUTPUT_TARGET}"
+    # this will be overwritten for each interface every time start-sqm or stop-sqm runs, so no danger here
+    if [ "${OUTPUT_TARGET}" = "${SQM_START_LOG}" ]; then
+        echo "$@" >> ${SQM_START_LOG}
+    fi
+    
+    if [ "${OUTPUT_TARGET}" = "${SQM_STOP_LOG}" ]; then
+        echo "$@" >> ${SQM_STOP_LOG}
+    fi
 }
 
 sqm_error() { sqm_logger $VERBOSITY_ERROR ERROR: "$@"; }
@@ -99,6 +108,33 @@ ipt() {
     iptables $* >> ${OUTPUT_TARGET} 2>&1
     sqm_trace "ip6tables $*"
     ip6tables $* >> ${OUTPUT_TARGET} 2>&1
+}
+
+ipt_new() {
+    d=$(echo $* | sed s/-A/-D/g)
+    [ "$d" != "$*" ] && {
+        ${IPTABLES} $d
+        sqm_trace "ip6tables ${d}"
+        ${IP6TABLES} $d
+    }
+    d=$(echo $* | sed s/-I/-D/g)
+    [ "$d" != "$*" ] && {
+        ${IPTABLES} $d
+        ${IP6TABLES} $d
+    }
+    ${IPTABLES} $*
+    ${IP6TABLES} $*
+}
+
+
+# wrapper to call iptables to allow debug logging
+iptables_wrapper(){
+    cmd_wrapper iptables ${IPTABLES_BINARY} "$@"
+}
+
+# wrapper to call ip6tables to allow debug logging
+ip6tables_wrapper(){
+    cmd_wrapper ip6tables ${IP6TABLES_BINARY} "$@"
 }
 
 # wrapper to call tc to allow debug logging

--- a/src/start-sqm
+++ b/src/start-sqm
@@ -14,6 +14,14 @@
 . ${SQM_LIB_DIR}/defaults.sh
 STATE_FILE="${SQM_STATE_DIR}/${IFACE}.state"
 
+OUTPUT_TARGET=${SQM_START_LOG}
+if [ -z "${SQM_DEBUG}" -o "${SQM_DEBUG}" -eq "0" ]; then
+    # create a new log file
+    echo "$(date): start-sqm logging started" > ${SQM_START_LOG}
+fi
+
+
+
 if [ -z "${SCRIPT}" ] ; then
     sqm_error "SCRIPT value is not defined in /etc/sqm/${IFACE}.iface.conf"
     sqm_error "Please check your configuration and try again."

--- a/src/stop-sqm
+++ b/src/stop-sqm
@@ -14,6 +14,14 @@
 . ${SQM_LIB_DIR}/functions.sh
 . ${SQM_LIB_DIR}/defaults.sh
 
+
+OUTPUT_TARGET=${SQM_STOP_LOG}
+if [ -n "${SQM_DEBUG}" -o "${SQM_DEBUG}" -eq "0" ]; then
+    # create a new log file
+    echo "$(date): stop-sqm logging started" > ${SQM_STOP_LOG}
+fi
+
+
 if [ ! -f "${SQM_STATE_DIR}/${IFACE}.state" ] ; then
     sqm_error "State file does not exists; SQM was not running on interface ${IFACE}"
     exit 1


### PR DESCRIPTION
I believe we can improve our logging game, and to get this going, here is a first propsal for the direction this should be going, IMHO. If this seems like a good idea we can see how to get rid of the legacy logging, which I believe to be much less useful than the proposed independent logging for run.sh, start-sqm and stop-sqm. 
The next step to improve and unify logging is to switch calls to ipt from open coding of output redirction to using cmd_wrapper(). This unfortunately also exposed some laxness in processing if iptables/ip6tables which we should also fix, IMHO...


Instead of using SQM_DEGUG to append all output into
a growing logfile, use three logfiles instead.
One for common code, mostly from run.sh, one for start-sqm and one for stop-sqm.
These logs are overwritten respectively on each invocation of either
run.sh, start-sqm or stop-sqm and will not grow indefintely and hence
can be enabled unconditionally so that this information is
available for debugging directly from "broken" sqm instances.

This commit also introduces ipt_new() in an attempt to convert
the legacy ipt() function to use cmd_wrapper to actually call
the iptables/ip6tables binaries. This exposes loads of errors
in ip[6]tables output and is hence not activated as default yet.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>


T