### PR TITLE
Switch ipt() from custom logging to employing cmd_wrapper()

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -25,10 +25,18 @@
 
 [ -z "$IQDISC_OPTS" ] && IQDISC_OPTS=""
 [ -z "$EQDISC_OPTS" ] && EQDISC_OPTS=""
+
+# handling of specific important binaries
 [ -z "$TC" ] && TC=tc_wrapper
 [ -z "$TC_BINARY" ] && TC_BINARY=$(which tc)
 [ -z "$IP" ] && IP=ip_wrapper
 [ -z "$IP_BINARY" ] && IP_BINARY=$(which ip)
+[ -z "$IPTABLES" ] && IPTABLES=iptables_wrapper
+[ -z "$IPTABLES_BINARY" ] && IPTABLES_BINARY=$(which iptables)
+[ -z "$IP6TABLES" ] && IP6TABLES=ip6tables_wrapper
+[ -z "$IP6TABLES_BINARY" ] && IP6TABLES_BINARY=$(which ip6tables)
+
+
 # Try modprobe first, fall back to insmod
 [ -z "$INSMOD" ] && INSMOD=$(which modprobe) || INSMOD=$(which insmod)
 [ -z "$TARGET" ] && TARGET="5ms"

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -80,20 +80,20 @@ fn_exists() {
 
 # to avoid unexpected side-effects first delete rules before adding them (again)
 ipt() {
-    d=$(echo $* | sed s/-A/-D/g)
+    d=$(echo "$*" | sed s/-A/-D/g)
     [ "$d" != "$*" ] && {
         SILENT=1 ${IPTABLES} $d
         SILENT=1 ${IP6TABLES} $d
     }
 
-    d=$(echo $* | sed s/-I/-D/g)
+    d=$(echo "$*" | sed s/-I/-D/g)
     [ "$d" != "$*" ] && {
         SILENT=1 ${IPTABLES} $d
         SILENT=1 ${IP6TABLES} $d
     }
 
-    SILENT=1 ${IPTABLES} $*
-    SILENT=1 ${IP6TABLES} $*
+    SILENT=1 ${IPTABLES} "$@"
+    SILENT=1 ${IP6TABLES} "$@"
 }
 
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -78,27 +78,33 @@ fn_exists() {
 }
 
 
-# ipt needs a toggle to show the outputs for debugging (as do all users of >
-# /dev/null 2>&1 and friends)
+# to avoid unexpected side-effects first delete rules before adding them (again)
 ipt() {
     d=$(echo $* | sed s/-A/-D/g)
     [ "$d" != "$*" ] && {
-        sqm_trace "iptables ${d}"
-        iptables $d >> ${OUTPUT_TARGET} 2>&1
-        sqm_trace "ip6tables ${d}"
-        ip6tables $d >> ${OUTPUT_TARGET} 2>&1
+        SILENT=1 ${IPTABLES} $d
+        SILENT=1 ${IP6TABLES} $d
     }
+
     d=$(echo $* | sed s/-I/-D/g)
     [ "$d" != "$*" ] && {
-        sqm_trace "iptables ${d}"
-        iptables $d >> ${OUTPUT_TARGET} 2>&1
-        sqm_trace "ip6tables ${d}"
-        ip6tables $d >> ${OUTPUT_TARGET} 2>&1
+        SILENT=1 ${IPTABLES} $d
+        SILENT=1 ${IP6TABLES} $d
     }
-    sqm_trace "iptables $*"
-    iptables $* >> ${OUTPUT_TARGET} 2>&1
-    sqm_trace "ip6tables $*"
-    ip6tables $* >> ${OUTPUT_TARGET} 2>&1
+
+    SILENT=1 ${IPTABLES} $*
+    SILENT=1 ${IP6TABLES} $*
+}
+
+
+# wrapper to call iptables to allow debug logging
+iptables_wrapper(){
+    cmd_wrapper iptables ${IPTABLES_BINARY} "$@"
+}
+
+# wrapper to call ip6tables to allow debug logging
+ip6tables_wrapper(){
+    cmd_wrapper ip6tables ${IP6TABLES_BINARY} "$@"
 }
 
 # wrapper to call tc to allow debug logging


### PR DESCRIPTION
It seems about time to regularize our usage of "important" binaries
by including iptables & ip6tables as users of cmd_wrapper.

The recent introduction of cmd_wrapper for important binaries
(tc, ip) left iptables and ip6tables usage in ipt() to use
custom logging. This switches ipt() over to use the wrappers,
To avoid log spew and to keep the situation compatible to the
status quo, this will sielnce all calls to ip[6]tables in ipt().

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>