### PR TITLE
Remove shebang in hotplug script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install: install-$(PLATFORM)
 install-openwrt: install-lib
 	install -m 0755 -d $(DESTDIR)/etc/hotplug.d/iface $(DESTDIR)/etc/config \
 		$(DESTDIR)/etc/init.d
-	install -m 0755 platform/openwrt/sqm-hotplug $(DESTDIR)/etc/hotplug.d/iface/11-sqm
+	install -m 0600 platform/openwrt/sqm-hotplug $(DESTDIR)/etc/hotplug.d/iface/11-sqm
 	install -m 0755 platform/openwrt/sqm-init $(DESTDIR)/etc/init.d/sqm
 	install -m 0644 platform/openwrt/sqm-uci $(DESTDIR)/etc/config/sqm
 	install -m 0744 src/run-openwrt.sh $(DESTDIR)$(PREFIX)/lib/sqm/run.sh

--- a/platform/openwrt/sqm-hotplug
+++ b/platform/openwrt/sqm-hotplug
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 [ -n "$DEVICE" ] || exit 0
 
 restart_sqm() {


### PR DESCRIPTION
Hotplug scripts are sourced so the shebang isn't relevant.  Update
Makefile to install with relevant permissions.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>