### PR TITLE
sqm@.service: add restart on failure

### DIFF
--- a/platform/linux/sqm@.service
+++ b/platform/linux/sqm@.service
@@ -13,6 +13,8 @@ Environment=IFACE=%i ENABLED=1
 ExecStart=/usr/lib/sqm/start-sqm
 ExecStop=/usr/lib/sqm/stop-sqm
 RemainAfterExit=1
+Restart=on-failure
+RestartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
there are situations where another 
systemd unit blocks boot for a while (up to 3 minutes)
to wait for other hardware initialization
before network is started.

The delay makes this unit time out and fail

Set a restart on failure with a generous delay
between restarts to work around the issue.

Signed-off-by: Alberto Bursi <bobafetthotmail@gmail.com>