### PR TITLE
Run service after network-online.target

### DIFF
--- a/platform/linux/sqm@.service
+++ b/platform/linux/sqm@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=SQM scripts for iface %i
-Wants=network.target
-Before=network.target
+Wants=network-online.target
+After=network-online.target
 BindsTo=sys-subsystem-net-devices-%i.device
 After=sys-subsystem-net-devices-%i.device
 


### PR DESCRIPTION
The service has to run after the network has been configured, so change
the ordering of the systemd unit after network-online.target.