### PR TITLE
Add INTERFACE to the ALL_DEVICES list in SQM's hotplug script

### DIFF
--- a/platform/openwrt/sqm-hotplug
+++ b/platform/openwrt/sqm-hotplug
@@ -1,6 +1,6 @@
 [ -n "$DEVICE" ] || exit 0
 
-ALL_DEVICES=$(echo $DEVICE $(uci -q get network.$INTERFACE.ifname) | tr ' ' '\n' | sort -u)
+ALL_DEVICES=$(echo $INTERFACE $DEVICE $(uci -q get network.$INTERFACE.ifname) | tr ' ' '\n' | sort -u)
 
 restart_sqm() {
     for dev in $ALL_DEVICES; do


### PR DESCRIPTION
I just noticed than on my turris omnia TOS 5.2.4 (based on OpenWrt 19.07) SQM's
hotplug on pppoe-wan was not working properly anymore.
The reasons seems to be that pppoe-wan is passed in as interface, but ALL_DEVICES did not contain $INTERFACE
Adding it results in working hotplug again, as tested by:

ACTION=ifdown INTERFACE=pppoe-wan DEVICE=eth2 /etc//hotplug.d/iface/11-sqm

ACTION=ifup INTERFACE=pppoe-wan DEVICE=eth2 /etc//hotplug.d/iface/11-sqm

with /etc/config/sqm containg a section for interface pppoe-wan.

Signed-off-by: Sebastian Moeller <moeller0@gmx.de>