### PR TITLE
defaults.sh: invoke modprobe quietly

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -39,7 +39,15 @@
 
 
 # Try modprobe first, fall back to insmod
-[ -z "$INSMOD" ] && { INSMOD=$(command -v modprobe) || INSMOD=$(command -v insmod); }
+if [ -z "$INSMOD" ]; then
+	INSMOD=$(command -v modprobe)
+	if [ -n "$INSMOD" ]; then
+		INSMOD="${INSMOD} -q"
+	else
+		INSMOD=$(command -v insmod)
+	fi
+fi
+
 [ -z "$TARGET" ] && TARGET="5ms"
 [ -z "$IPT_MASK" ] && IPT_MASK="0xff" # to disable: set mask to 0xffffffff
 #sm: we need the functions above before trying to set the ingress IFB device


### PR DESCRIPTION
In OpenWrt, if the required qdisc and classifier modules are built-in, modprobe
complains, rather loudly, for not being able to find them. This unnecessarily
fills the log with pointless error messages, so let's quiet it down.

Signed-off-by: Rui Salvaterra \<rsalvaterra@gmail.com\>