### PR TITLE
systemd: pivot WantedBy to interface rather than multi-user

### DIFF
--- a/platform/linux/sqm@.service
+++ b/platform/linux/sqm@.service
@@ -15,4 +15,4 @@ ExecStop=/usr/lib/sqm/stop-sqm
 RemainAfterExit=1
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sys-devices-virtual-net-%i.device


### PR DESCRIPTION
Fixes SQM restarts (issue https://github.com/tohojo/sqm-scripts/issues/143) when the interface is removed and re-added (eg. PPP) and also SQM loads sooner rather than waiting for multi-user to start