### PR TITLE
Add cleanup action for cleaning up after a device is removed

### DIFF
--- a/platform/linux/sqm-bin
+++ b/platform/linux/sqm-bin
@@ -3,6 +3,12 @@
 . /etc/sqm/sqm.conf
 ACTION="$1"
 RUN_IFACE="$2"
+CLEANUP=0
+
+if [ "$ACTION" = "cleanup" ]; then
+    CLEANUP=1
+    ACTION=stop
+fi
 
 if [ "$(id -u)" -ne "0" ]; then
     echo "This script must be run as root." >&2
@@ -10,7 +16,7 @@ if [ "$(id -u)" -ne "0" ]; then
 fi
 
 if [ "$ACTION" != "start" -a "$ACTION" != "stop" -a "$ACTION" != "reload" ]; then
-    echo "Usage: $0 <start|stop|reload> [iface]." >&2
+    echo "Usage: $0 <start|stop|reload|cleanup> [iface]." >&2
     exit 1
 fi
 
@@ -20,7 +26,7 @@ if [ "$ACTION" = "stop" -a -z "$RUN_IFACE" ]; then
     for f in ${SQM_STATE_DIR}/*.state; do
         # Source the state file prior to stopping; we need the $IFACE and
         # $SCRIPT variables saved in there.
-        [ -f "$f" ] && ( . $f; IFACE=$IFACE SCRIPT=$SCRIPT SQM_DEBUG=$SQM_DEBUG SQM_DEBUG_LOG=$SQM_DEBUG_LOG OUTPUT_TARGET=$OUTPUT_TARGET ${SQM_LIB_DIR}/stop-sqm )
+        [ -f "$f" ] && ( . $f; IFACE=$IFACE SCRIPT=$SCRIPT CLEANUP=$CLEANUP SQM_DEBUG=$SQM_DEBUG SQM_DEBUG_LOG=$SQM_DEBUG_LOG OUTPUT_TARGET=$OUTPUT_TARGET ${SQM_LIB_DIR}/stop-sqm )
     done
     exit 0
 fi

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -104,6 +104,10 @@ fi
 # particular command
 SILENT=0
 
+# If set to 1, stop-sqm will run the (silent) cleanup function instead of a full
+# stop operation
+[ -z "$CLEANUP" ] && CLEANUP=0
+
 # Transaction log for unwinding ipt rules
 IPT_TRANS_LOG="${SQM_STATE_DIR}/${IFACE}.iptables.log"
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -543,8 +543,6 @@ sqm_stop() {
     if [ "${DOWNLINK}" -ne 0 ]; then
        $TC qdisc del dev $IFACE ingress
        $TC qdisc del dev $IFACE root
-       [ -n "$CUR_IFB" ] && $TC qdisc del dev $CUR_IFB root
-       [ -n "$CUR_IFB" ] && sqm_debug "${0}: ${CUR_IFB} shaper deleted"
     fi
 
     # undo accumulated ipt commands during shutdown

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -539,16 +539,26 @@ sqm_start_default() {
 }
 
 
-sqm_stop() {
-    [ "${DOWNLINK}" -ne 0 ] && $TC qdisc del dev $IFACE ingress
-    $TC qdisc del dev $IFACE root
+sqm_cleanup()
+{
+    local silent
+    silent=${1:-0}
 
     # undo accumulated ipt commands during shutdown
     ipt_log_rewind
 
-    [ -n "$CUR_IFB" ] && $IP link set dev ${CUR_IFB} down
-    [ -n "$CUR_IFB" ] && $IP link delete ${CUR_IFB} type ifb
-    [ -n "$CUR_IFB" ] && sqm_debug "${0}: ${CUR_IFB} interface deleted"
+    [ -n "$CUR_IFB" ] || return 0
+
+    SILENT=$silent $IP link delete dev ${CUR_IFB} type ifb
+    sqm_debug "${0}: ${CUR_IFB} interface deleted"
+}
+
+
+sqm_stop() {
+    [ "${DOWNLINK}" -ne 0 ] && $TC qdisc del dev $IFACE ingress
+    $TC qdisc del dev $IFACE root
+
+    sqm_cleanup
 }
 
 # Note this has side effects on the prio variable

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -540,10 +540,8 @@ sqm_start_default() {
 
 
 sqm_stop() {
-    if [ "${DOWNLINK}" -ne 0 ]; then
-       $TC qdisc del dev $IFACE ingress
-       $TC qdisc del dev $IFACE root
-    fi
+    [ "${DOWNLINK}" -ne 0 ] && $TC qdisc del dev $IFACE ingress
+    $TC qdisc del dev $IFACE root
 
     # undo accumulated ipt commands during shutdown
     ipt_log_rewind

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -141,6 +141,9 @@ ipt_log_rewind() {
             [ -n "$line" ] || continue
             ipt_run_split "$line"
         done
+
+    # We just rewound the log, make sure to restart it
+    ipt_log_restart
 }
 
 ipt() {
@@ -546,8 +549,6 @@ sqm_stop() {
 
     # undo accumulated ipt commands during shutdown
     ipt_log_rewind
-    # reset the iptables trace log
-    ipt_log_restart
 
     [ -n "$CUR_IFB" ] && $IP link set dev ${CUR_IFB} down
     [ -n "$CUR_IFB" ] && $IP link delete ${CUR_IFB} type ifb

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -16,6 +16,12 @@ ACTION="${1:-start}"
 RUN_IFACE="$2"
 LOCKDIR="${SQM_STATE_DIR}/sqm-run.lock"
 
+CLEANUP=0
+if [ "$ACTION" = "cleanup" ]; then
+    CLEANUP=1
+    ACTION=stop
+fi
+
 check_state_dir
 [ -d "${SQM_QDISC_STATE_DIR}" ] || ${SQM_LIB_DIR}/update-available-qdiscs
 
@@ -26,7 +32,7 @@ stop_statefile() {
     # there.
     [ -f "$f" ] && ( . "$f";
                      IFACE=$IFACE SCRIPT=$SCRIPT SQM_DEBUG=$SQM_DEBUG \
-                          SQM_DEBUG_LOG=$SQM_DEBUG_LOG \
+                          SQM_DEBUG_LOG=$SQM_DEBUG_LOG CLEANUP=$CLEANUP \
                           SQM_VERBOSITY_MAX=$SQM_VERBOSITY_MAX \
                           SQM_VERBOSITY_MIN=$SQM_VERBOSITY_MIN \
                           OUTPUT_TARGET=$OUTPUT_TARGET ${SQM_LIB_DIR}/stop-sqm )

--- a/src/stop-sqm
+++ b/src/stop-sqm
@@ -35,7 +35,6 @@ if [ -z "${SCRIPT}" ] ; then
 fi
 
 sqm_trace; sqm_trace "$(date): Stopping." # Add some space and a date stamp to verbose log output and log files to separate runs
-sqm_log "Stopping SQM on ${IFACE}"
 
 # make sure to only delete the ifb associated with the current interface
 CUR_IFB=$( get_ifb_associated_with_if ${IFACE} )
@@ -48,7 +47,13 @@ fi
 
 . "${SQM_LIB_DIR}/$SCRIPT"
 
-sqm_stop
+if [ "$CLEANUP" -eq "1" ]; then
+    sqm_log "Cleaning up SQM state on ${IFACE}"
+    sqm_cleanup 1
+else
+    sqm_log "Stopping SQM on ${IFACE}"
+    sqm_stop
+fi
 rm -f "${STATE_FILE}"
 
 exit 0


### PR DESCRIPTION
Add a new 'cleanup' action for cleaning up SQM state after an interface that has
gone away. Refactor the stop code a bit in the process, most notably to fix
stopping in the case where no downstream shaper is configured.

Fixes #155.