### PR TITLE
openwrt/hotplug: Handle DSA switch port configs

### DIFF
--- a/platform/openwrt/sqm-hotplug
+++ b/platform/openwrt/sqm-hotplug
@@ -1,6 +1,29 @@
+#!/bin.sh
+
+. /lib/functions.sh
+
 [ -n "$DEVICE" ] || exit 0
 
-ALL_DEVICES=$(echo $DEVICE $(uci -q get network.$INTERFACE.ifname) | tr ' ' '\n' | sort -u)
+list_ports() {
+    local section
+    local find_name
+    local devname
+    section="$1"
+    find_name="$2"
+    devname=$(config_get "$section" "name")
+    [ "$devname" = "$find_name" ] || return
+    config_get "$section" "ports"
+}
+
+ports_for_device() {
+    local devname
+    devname=$1
+    [ -z "$devname" ] && return
+    config_load network
+    config_foreach list_ports device "$devname"
+}
+
+ALL_DEVICES=$(echo $DEVICE $(uci -q get network.$INTERFACE.ifname) $(ports_for_device $(uci -q get network.$INTERFACE.device)) | tr ' ' '\n' | sort -u)
 
 restart_sqm() {
     for dev in $ALL_DEVICES; do


### PR DESCRIPTION
In the OpenWrt hotplug script we handle the case where the interface hotplug event arrives for the bridge interface by querying uci to find the underlying devices that are part of the bridge and restarting any configured SQM instances on the ports. However, with the switch to DSA, we can no longer find the bridge ports in the network.$INTERFACE.ifname property. Instead, we have to query the 'device' property and locate the separate device config section to find the port names.

Add a function to do this querying, but keep the ifname query to retain compatibility with old configs (it's harmless if the parameter is empty).

Fixes #163 