### PR TITLE
Add nat to the default [IN|E]GRESS_CAKE_OPTS in defaults.sh

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -54,8 +54,8 @@ fi
 [ -z "$IPT_MASK" ] && IPT_MASK="0xff" # to disable: set mask to 0xffffffff
 #sm: we need the functions above before trying to set the ingress IFB device
 #sm: *_CAKE_OPTS should contain the diffserv keyword for cake
-[ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3"
-[ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3"
+[ -z "$INGRESS_CAKE_OPTS" ] && INGRESS_CAKE_OPTS="diffserv3 nat"
+[ -z "$EGRESS_CAKE_OPTS" ] && EGRESS_CAKE_OPTS="diffserv3 nat"
 
 [ -z "$CUR_DIRECTION" ] && CUR_DIRECTION="NONE"
 

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -13,9 +13,11 @@
 QDISC=cake
 
 
-# to keep this as simple as possible we ignore the *_CAKE_OPTS from defaults.sh
-INGRESS_CAKE_OPTS="besteffort"
-EGRESS_CAKE_OPTS="besteffort"
+# to keep this as simple as possible we append the *_CAKE_OPTS from defaults.sh
+# since cake will always just keep the last instance of competing keywords this
+# will effectively override defaults.sh's diffservX
+INGRESS_CAKE_OPTS="${INGRESS_CAKE_OPTS} besteffort"
+EGRESS_CAKE_OPTS="${EGRESSS_CAKE_OPTS} besteffort"
 
 
 egress() {


### PR DESCRIPTION
For most users the nat lookup seems to be the best default, so add nat to the default cake options in defaults.sh. piece_of_cake was ignoring these cake options so far, instead simply append the besteffort keyword to INGRESS_CAKE_OPTS and EGRESS_CAKE_OPTS which will retain all other defaults... 