### PR TITLE
functions.sh: make IFB interface name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ once.
 Because qdiscs only see traffic as it is *leaving* an interface, for ingress
 shaping sqm-scripts sets up an IFB device. Incoming packets are redirected to
 this device where a regular qdisc can handle them. The IFB device is named for
-the egress interface it is paired with, so the IFB for 'eth0' will be called
-'ifb4eth0'.
+the egress interface it is paired with, so the IFB for `eth0` will be called
+`ifb4eth0` (use `$IFB_PATTERN` in the configuration file to change the naming).
 
 This is all illustrated on the following diagram:
 

--- a/platform/linux/default.conf
+++ b/platform/linux/default.conf
@@ -44,3 +44,5 @@ SCRIPT=piece_of_cake.qos
 #ZERO_DSCP_INGRESS=1
 #IGNORE_DSCP_INGRESS=1
 
+# Name of the IFB interface, as a printf(1) format string
+#IFB_PATTERN="ifb4%s"

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -26,6 +26,8 @@
 [ -z "$IQDISC_OPTS" ] && IQDISC_OPTS=""
 [ -z "$EQDISC_OPTS" ] && EQDISC_OPTS=""
 
+[ -z "$IFB_PATTERN" ] && IFB_PATTERN="ifb4%s"
+
 # handling of specific important binaries
 [ -z "$TC" ] && TC=tc_wrapper
 [ -z "$TC_BINARY" ] && TC_BINARY=$(command -v tc)

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -333,8 +333,7 @@ ifb_name() {
     local NEW_IFB
     CUR_IF=$1
     MAX_IF_NAME_LENGTH=15
-    IFB_PREFIX="ifb4"
-    NEW_IFB=$( echo -n "${IFB_PREFIX}${CUR_IF}" | head -c $MAX_IF_NAME_LENGTH )
+    NEW_IFB=$( printf "${IFB_PATTERN}" "${CUR_IF}" | head -c $MAX_IF_NAME_LENGTH )
 
     echo ${NEW_IFB}
 }


### PR DESCRIPTION
Accept a new variable `$IFB_PATTERN` which is used as a printf(1)
pattern to generate the IFB interface name from the primary interface
name. The default is `ifb4%s` which corresponds to the pre-existing
behavior.

Signed-off-by: Ivan Shapovalov <intelfx@intelfx.name>
