### PR TITLE
default.sh: fix USE_MQ logic

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -19,7 +19,7 @@
 [ -z "$ETARGET" ] && ETARGET=
 [ -z "$IECN" ] && IECN="ECN"
 [ -z "$EECN" ] && EECN="ECN"
-[ -z "$USE_MQ" ] && USE_MQ=0
+[ -z "$USE_MQ" ] && USE_MQ=1
 # These two used to be called something else; preserve backwards compatibility
 [ -z "$ZERO_DSCP_INGRESS" ] && ZERO_DSCP_INGRESS="${ZERO_DSCP:-${SQUASH_DSCP:-1}}"
 [ -z "$IGNORE_DSCP_INGRESS" ] && IGNORE_DSCP_INGRESS="${IGNORE_DSCP:-${SQUASH_INGRESS:-1}}"
@@ -99,9 +99,6 @@ then
 else
     OUTPUT_TARGET="/dev/null"
 fi
-
-# .qos script must declare support, or this will be disabled
-[ -n "$SUPPORT_MQ" ] && USE_MQ=1
 
 # Can be overridden by callers that want to silence error output for a
 # particular command

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -19,7 +19,7 @@
 [ -z "$ETARGET" ] && ETARGET=
 [ -z "$IECN" ] && IECN="ECN"
 [ -z "$EECN" ] && EECN="ECN"
-[ -z "$USE_MQ" ] && USE_MQ=1
+[ -z "$USE_MQ" ] && USE_MQ=0
 # These two used to be called something else; preserve backwards compatibility
 [ -z "$ZERO_DSCP_INGRESS" ] && ZERO_DSCP_INGRESS="${ZERO_DSCP:-${SQUASH_DSCP:-1}}"
 [ -z "$IGNORE_DSCP_INGRESS" ] && IGNORE_DSCP_INGRESS="${IGNORE_DSCP:-${SQUASH_INGRESS:-1}}"
@@ -101,7 +101,7 @@ else
 fi
 
 # .qos script must declare support, or this will be disabled
-[ -z "$SUPPORT_MQ" ] && USE_MQ=0
+[ -n "$SUPPORT_MQ" ] && USE_MQ=1
 
 # Can be overridden by callers that want to silence error output for a
 # particular command

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,9 +352,18 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local CUR_IFB
-    CUR_IFB=${1}
-    $IP link add name ${CUR_IFB} type ifb
+    local name
+    local args
+    local num_procs
+    name=$1
+    args=
+
+    num_procs=$(grep -c processor /proc/cpuinfo)
+
+    if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
+        args="numtxqueues $num_procs"
+    fi
+    $IP link add name $name $args type ifb
 }
 
 delete_ifb() {

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -955,6 +955,10 @@ eth_setup() {
     fi
 }
 
+mq_enabled() {
+    [ "$USE_MQ" -eq "1" ] && [ "$SUPPORT_MQ" -eq 1 ]
+}
+
 select_cake() {
     local interface
     local num_queues
@@ -964,7 +968,7 @@ select_cake() {
     qdisc=cake
 
     # cake_mq only works on multiqueue devices
-    if [ "$USE_MQ" -eq "1" ] && [ "$num_queues" -gt "1" ] && verify_qdisc cake_mq; then
+    if mq_enabled && [ "$num_queues" -gt "1" ] && verify_qdisc cake_mq; then
         qdisc=cake_mq
     fi
 

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,9 +352,18 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local CUR_IFB
-    CUR_IFB=${1}
-    $IP link add name ${CUR_IFB} type ifb
+    local name
+    local args
+    local num_procs
+    name=$1
+    args=
+
+    num_procs=$(grep -c processor /proc/cpuinfo)
+
+    if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
+        args="numtxqueues $num_procs"
+    fi
+    $IP link add name $name $args type ifb
 }
 
 delete_ifb() {
@@ -401,7 +410,6 @@ verify_qdisc() {
     root_string="root" # this works for most qdiscs
     args=""
     IFB_MTU=1514
-    dev=$ifb
 
     if [ -n "$supported" ]; then
         found=0
@@ -422,23 +430,14 @@ verify_qdisc() {
 	    IFB_MTU=$(( ${IFB_MTU} + 14 )) # TBF's warning is confused, it says MTU but it checks MTU + 14
 	    args="limit 1 burst ${IFB_MTU} rate 1kbps"
 	    ;;
-        #cake_mq needs to be tested on a multi-queue device
-        #ip command in busybox does not support creating a multi tx queue ifb device
-        #thus test cake_mq on the real interface.
-        cake_mq) dev=$IFACE ;; 
     esac
 
-    $TC qdisc replace dev $dev $root_string $qdisc $args
+    $TC qdisc replace dev $ifb $root_string $qdisc $args
     res=$?
     if [ "$res" = "0" ] ; then
         sqm_debug "QDISC $qdisc is useable."
     else
         sqm_error "QDISC $qdisc is NOT useable."
-    fi
-
-    #clean up in case IFACE was used to test qdisc
-    if [ "$dev" = "$IFACE" ];then
-        $TC qdisc del dev $dev $root_string
     fi
     delete_ifb $ifb
     return $res

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -956,10 +956,6 @@ eth_setup() {
     fi
 }
 
-mq_enabled() {
-    [ "$USE_MQ" -eq "1" ] && [ "$SUPPORT_MQ" -eq 1 ]
-}
-
 select_cake() {
     local interface
     local num_queues
@@ -969,11 +965,29 @@ select_cake() {
     qdisc=cake
 
     # cake_mq only works on multiqueue devices
-    if mq_enabled && [ "$num_queues" -gt "1" ] && verify_qdisc cake_mq; then
+    if [ "$USE_MQ" -eq "1" ] && [ "$SUPPORT_MQ" -eq 1 ] && [ "$num_queues" -gt "1" ]; then
         qdisc=cake_mq
     fi
 
     sqm_debug "Using $qdisc for interface $interface with $num_queues TXQs"
     echo $qdisc
     return 0
+}
+
+install_cake() {
+    local iface
+    local qdisc
+    local res
+    iface=$1
+    shift
+
+    qdisc=$(select_cake $iface)
+    $TC qdisc replace dev $iface root $qdisc "$@"
+    res=$?
+    if [ "$res" -ne "0" ] && [ "$qdisc" = "cake_mq" ]; then
+        $TC qdisc replace dev $iface root cake "$@"
+        res=$?
+        sqm_debug "Failed to install cake_mq. Falling back to cake."
+    fi
+    return $res
 }

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,18 +352,9 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local name
-    local args
-    local num_procs
-    name=$1
-    args=
-
-    num_procs=$(grep -c processor /proc/cpuinfo)
-
-    if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
-        args="numtxqueues $num_procs"
-    fi
-    $IP link add name $name $args type ifb
+    local CUR_IFB
+    CUR_IFB=${1}
+    $IP link add name ${CUR_IFB} type ifb
 }
 
 delete_ifb() {

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,18 +352,9 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local name
-    local args
-    local num_procs
-    name=$1
-    args=
-
-    num_procs=$(grep -c processor /proc/cpuinfo)
-
-    if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
-        args="numtxqueues $num_procs"
-    fi
-    $IP link add name $name $args type ifb
+    local CUR_IFB
+    CUR_IFB=${1}
+    $IP link add name ${CUR_IFB} type ifb
 }
 
 delete_ifb() {
@@ -410,6 +401,7 @@ verify_qdisc() {
     root_string="root" # this works for most qdiscs
     args=""
     IFB_MTU=1514
+    dev=$ifb
 
     if [ -n "$supported" ]; then
         found=0
@@ -430,14 +422,23 @@ verify_qdisc() {
 	    IFB_MTU=$(( ${IFB_MTU} + 14 )) # TBF's warning is confused, it says MTU but it checks MTU + 14
 	    args="limit 1 burst ${IFB_MTU} rate 1kbps"
 	    ;;
+        #cake_mq needs to be tested on a multi-queue device
+        #ip command in busybox does not support creating a multi tx queue ifb device
+        #thus test cake_mq on the real interface.
+        cake_mq) dev=$IFACE ;; 
     esac
 
-    $TC qdisc replace dev $ifb $root_string $qdisc $args
+    $TC qdisc replace dev $dev $root_string $qdisc $args
     res=$?
     if [ "$res" = "0" ] ; then
         sqm_debug "QDISC $qdisc is useable."
     else
         sqm_error "QDISC $qdisc is NOT useable."
+    fi
+
+    #clean up in case IFACE was used to test qdisc
+    if [ "$dev" = "$IFACE" ];then
+        $TC qdisc del dev $dev $root_string
     fi
     delete_ifb $ifb
     return $res

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -972,10 +972,10 @@ install_cake() {
     shift
 
     qdisc=$(select_cake $iface)
-    $TC qdisc replace dev $iface root $( get_stab_string ) $qdisc "$@"
+    $TC qdisc replace dev $iface root $qdisc "$@"
     res=$?
     if [ "$res" -ne "0" ] && [ "$qdisc" = "cake_mq" ]; then
-        $TC qdisc replace dev $iface root $( get_stab_string ) cake "$@"
+        $TC qdisc replace dev $iface root cake "$@"
         res=$?
         sqm_warn "Failed to install cake_mq. Falling back to cake."
     fi

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -986,7 +986,7 @@ install_cake() {
     if [ "$res" -ne "0" ] && [ "$qdisc" = "cake_mq" ]; then
         $TC qdisc replace dev $iface root $( get_stab_string ) cake "$@"
         res=$?
-        sqm_debug "Failed to install cake_mq. Falling back to cake."
+        sqm_warn "Failed to install cake_mq. Falling back to cake."
     fi
     return $res
 }

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -981,10 +981,10 @@ install_cake() {
     shift
 
     qdisc=$(select_cake $iface)
-    $TC qdisc replace dev $iface root $qdisc "$@"
+    $TC qdisc replace dev $iface root $( get_stab_string ) $qdisc "$@"
     res=$?
     if [ "$res" -ne "0" ] && [ "$qdisc" = "cake_mq" ]; then
-        $TC qdisc replace dev $iface root cake "$@"
+        $TC qdisc replace dev $iface root $( get_stab_string ) cake "$@"
         res=$?
         sqm_debug "Failed to install cake_mq. Falling back to cake."
     fi

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -360,6 +360,8 @@ create_ifb() {
 
     num_procs=$(grep -c processor /proc/cpuinfo)
 
+    # It is possible that this does not create multiple tx-queues because 
+    # some versions of 'ip' do not support it. (e.g., busybox 1.37.0) 
     if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
         args="numtxqueues $num_procs"
     fi

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -21,10 +21,8 @@ QDISC=cake
 egress() {
     local qdisc
     SILENT=1 $TC qdisc del dev $IFACE root
-    install_cake $IFACE bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
-    $TC qdisc add dev $IFACE 
+    install_cake $IFACE \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
-
 }
 
 

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -19,7 +19,6 @@ QDISC=cake
 
 
 egress() {
-    local qdisc
     SILENT=1 $TC qdisc del dev $IFACE root
     install_cake $IFACE \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
@@ -27,9 +26,6 @@ egress() {
 
 
 ingress() {
-    local qdisc
-    qdisc=$(select_cake $DEV)
-
     SILENT=1 $TC qdisc del dev $IFACE handle ffff: ingress
     $TC qdisc add dev $IFACE handle ffff: ingress
 
@@ -38,7 +34,7 @@ ingress() {
     [ "$IGNORE_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS besteffort"
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) $qdisc \
+    install_cake $DEV \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -20,9 +20,9 @@ QDISC=cake
 
 egress() {
     local qdisc
-    qdisc=$(select_cake $IFACE)
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) $qdisc \
+    install_cake $IFACE bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
+    $TC qdisc add dev $IFACE 
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 
 }

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -24,9 +24,8 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 egress() {
     local qdisc
     sqm_debug "egress"
-    qdisc=$(select_cake $IFACE)
     SILENT=1 $TC qdisc del dev $IFACE root
-    install_cake $IFACE root $( get_stab_string ) $qdisc \
+    install_cake $IFACE \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
 

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -22,7 +22,6 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 
 
 egress() {
-    local qdisc
     sqm_debug "egress"
     SILENT=1 $TC qdisc del dev $IFACE root
     install_cake $IFACE \
@@ -31,9 +30,7 @@ egress() {
 
 
 ingress() {
-    local qdisc
     sqm_debug "ingress"
-    qdisc=$(select_cake $DEV)
 
     SILENT=1 $TC qdisc del dev $IFACE handle ffff: ingress
     $TC qdisc add dev $IFACE handle ffff: ingress
@@ -41,7 +38,7 @@ ingress() {
 
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) $qdisc \
+    install_cake $DEV $qdisc \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -26,7 +26,7 @@ egress() {
     sqm_debug "egress"
     qdisc=$(select_cake $IFACE)
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) $qdisc \
+    install_cake $IFACE root $( get_stab_string ) $qdisc \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
 


### PR DESCRIPTION
Before USE_MQ would be always set to zero if default.sh was included by a script that did not set SUPPORT_MQ. Once USE_MQ was set to zero, it could never be set to 1 again. This patch inverts this logic, such that whenever SUPPORT_MQ is set, USE_MQ is also set.