### PR TITLE
sqm: gate USE_MQ after loading the selected qdisc script

### DIFF
--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -100,9 +100,6 @@ else
     OUTPUT_TARGET="/dev/null"
 fi
 
-# .qos script must declare support, or this will be disabled
-[ -z "$SUPPORT_MQ" ] && USE_MQ=0
-
 # Can be overridden by callers that want to silence error output for a
 # particular command
 SILENT=0

--- a/src/start-sqm
+++ b/src/start-sqm
@@ -52,6 +52,9 @@ fi
 
 . "${SQM_LIB_DIR}/$SCRIPT"
 
+# Only scripts explicitly declaring SUPPORT_MQ=1 may use multiqueue mode.
+[ "${SUPPORT_MQ:-0}" -eq "1" ] || USE_MQ=0
+
 sqm_trace; sqm_trace "$(date): Starting." # Add some space and a date stamp to verbose log output and log files to separate runs
 sqm_log "Starting SQM script: ${SCRIPT} on ${IFACE}, in: ${DOWNLINK} Kbps, out: ${UPLINK} Kbps"
 


### PR DESCRIPTION
start-sqm sources defaults.sh before the selected *.qos script, so SUPPORT_MQ is not yet set at that point. This can force USE_MQ=0 even for scripts that declare SUPPORT_MQ=1 (e.g. piece_of_cake.qos).

Move the SUPPORT_MQ gate to start-sqm after loading the selected script, and keep per-interface cake_mq selection in select_cake().

I alreay see an other PR https://github.com/tohojo/sqm-scripts/pull/183
So, feel free to close this one in any case is redundant

Run tested on openwrt snapshot with Gl.inet MT6000