### PR TITLE
Cake mq support v2

### DIFF
--- a/platform/linux/default.conf
+++ b/platform/linux/default.conf
@@ -44,5 +44,3 @@ SCRIPT=piece_of_cake.qos
 #ZERO_DSCP_INGRESS=1
 #IGNORE_DSCP_INGRESS=1
 
-# Whether to enable the use of multi-queue qdiscs (such as cake_mq) when supported
-#USE_MQ=1

--- a/platform/openwrt/sqm-uci
+++ b/platform/openwrt/sqm-uci
@@ -13,5 +13,4 @@ config queue 'eth1'
         option itarget 'auto'
         option etarget 'auto'
         option linklayer 'none'
-        option use_mq '1'
 

--- a/platform/openwrt/sqm.conf
+++ b/platform/openwrt/sqm.conf
@@ -1,7 +1,7 @@
 SQM_LIB_DIR=/usr/lib/sqm
 SQM_STATE_DIR=/var/run/sqm
 SQM_QDISC_STATE_DIR=${SQM_STATE_DIR}/available_qdiscs
-SQM_CHECK_QDISCS="fq_codel codel pie sfq cake"
+SQM_CHECK_QDISCS="fq_codel codel pie sfq cake cake_mq"
 SQM_SYSLOG=1
 IP6TABLES_BINARY=$(command -v ip6tables-nft)
 IPTABLES_BINARY=$(command -v iptables-nft)

--- a/src/defaults.sh
+++ b/src/defaults.sh
@@ -19,7 +19,6 @@
 [ -z "$ETARGET" ] && ETARGET=
 [ -z "$IECN" ] && IECN="ECN"
 [ -z "$EECN" ] && EECN="ECN"
-[ -z "$USE_MQ" ] && USE_MQ=1
 # These two used to be called something else; preserve backwards compatibility
 [ -z "$ZERO_DSCP_INGRESS" ] && ZERO_DSCP_INGRESS="${ZERO_DSCP:-${SQUASH_DSCP:-1}}"
 [ -z "$IGNORE_DSCP_INGRESS" ] && IGNORE_DSCP_INGRESS="${IGNORE_DSCP:-${SQUASH_INGRESS:-1}}"
@@ -100,8 +99,6 @@ else
     OUTPUT_TARGET="/dev/null"
 fi
 
-# .qos script must declare support, or this will be disabled
-[ -z "$SUPPORT_MQ" ] && USE_MQ=0
 
 # Can be overridden by callers that want to silence error output for a
 # particular command

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -954,21 +954,3 @@ eth_setup() {
        done
     fi
 }
-
-select_cake() {
-    local interface
-    local num_queues
-    local qdisc
-    interface=$1
-    num_queues=$(ls -d /sys/class/net/$interface/queues/tx-* | wc -l)
-    qdisc=cake
-
-    # cake_mq only works on multiqueue devices
-    if [ "$USE_MQ" -eq "1" ] && [ "$num_queues" -gt "1" ] && verify_qdisc cake_mq; then
-        qdisc=cake_mq
-    fi
-
-    sqm_debug "Using $qdisc for interface $interface with $num_queues TXQs"
-    echo $qdisc
-    return 0
-}

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -454,6 +454,20 @@ verify_qdisc() {
     return $res
 }
 
+verify_qdisc_for_if() {
+    verify_qdisc "$@" || false 
+    case $qdisc in
+        cake_mq)
+        num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
+        if [ "$num_queues" -le "1" ]; then
+            sqm_error "Hardware does not support multiple transmission queues. \
+                Cannot use cake_mq on interface $IFACE."
+            return false
+        fi
+        ;;
+    esac
+}
+
 
 get_htb_adsll_string() {
     ADSLL=""
@@ -527,7 +541,7 @@ sqm_start_default() {
     fi
 
     do_modules
-    verify_qdisc $QDISC || return 1
+    verify_qdisc_for_if $QDISC || return 1
     sqm_debug "sqm_start_default: Starting ${SCRIPT}"
 
     [ -z "$DEV" ] && DEV=$( get_ifb_for_if ${IFACE} )

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,18 +352,9 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local name
-    local args
-    local num_procs
-    name=$1
-    args=
-
-    num_procs=$(grep -c processor /proc/cpuinfo)
-
-    if [ "$USE_MQ" -eq "1" ] && [ "$num_procs" -gt 1 ]; then
-        args="numtxqueues $num_procs"
-    fi
-    $IP link add name $name $args type ifb
+    local CUR_IFB
+    CUR_IFB=${1}
+    $IP link add name ${CUR_IFB} type ifb
 }
 
 delete_ifb() {

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -352,9 +352,20 @@ create_new_ifb_for_if() {
 
 # TODO: report failures
 create_ifb() {
-    local CUR_IFB
-    CUR_IFB=${1}
-    $IP link add name ${CUR_IFB} type ifb
+    local name
+    local args
+    local num_procs
+    name=$1
+    use_mq=$2
+    args=
+
+    num_procs=$(grep -c processor /proc/cpuinfo)
+
+    if [ "$use_mq" = "1" ] && [ "$num_procs" -gt 1 ]; then
+        args="numtxqueues $num_procs"
+    fi
+    $IP link add name $name $args type ifb || return false
+
 }
 
 delete_ifb() {
@@ -400,6 +411,7 @@ verify_qdisc() {
     ifb=SQM_IFB_$randnum
     root_string="root" # this works for most qdiscs
     args=""
+    use_mq=0
     IFB_MTU=1514
 
     if [ -n "$supported" ]; then
@@ -409,7 +421,8 @@ verify_qdisc() {
         done
         [ "$found" -eq "1" ] || return 1
     fi
-    create_ifb $ifb || return 1
+    [ "$qdisc" = "cake_mq" ] && use_mq=1
+    create_ifb $ifb $use_mq || return 1
 
 
     case $qdisc in
@@ -421,6 +434,13 @@ verify_qdisc() {
 	    IFB_MTU=$(( ${IFB_MTU} + 14 )) # TBF's warning is confused, it says MTU but it checks MTU + 14
 	    args="limit 1 burst ${IFB_MTU} rate 1kbps"
 	    ;;
+        cake_mq)
+        num_queues=$(ls -d /sys/class/net/$name/queues/tx-* | wc -l)
+        if [ "$num_queues" -le "1" ]; then
+            sqm_warning "ip could not create a multi tx queue device. \
+                Please install iputils-ip, if you want to use $qdisc."
+        fi
+        ;;
     esac
 
     $TC qdisc replace dev $ifb $root_string $qdisc $args

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -433,8 +433,8 @@ verify_qdisc() {
         cake_mq)
         num_queues=$(ls -d /sys/class/net/$ifb/queues/tx-* | wc -l)
         if [ "$num_queues" -le "1" ]; then
-            sqm_warn "ip could not create a multi tx queue device. \
-                Please install ip-full, if you want to use $qdisc."
+            sqm_warn "ip could not create a multi tx queue device." \
+               "Please install ip-full, if you want to use $qdisc."
         fi
         ;;
     esac
@@ -456,8 +456,8 @@ verify_qdisc_for_if() {
         cake_mq)
         num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
         if [ "$num_queues" -le "1" ]; then
-            sqm_error "Hardware does not support multiple transmission queues. \
-                Cannot use cake_mq on interface $IFACE."
+            sqm_error "Hardware does not support multiple transmission queues." \
+               "Cannot use cake_mq on interface $IFACE."
             return false
         fi
         ;;
@@ -531,7 +531,7 @@ sqm_start_default() {
 
     if fn_exists sqm_prepare_script ; then
 	sqm_debug "sqm_start_default: starting sqm_prepare_script"
-        sqm_prepare_script
+    sqm_prepare_script || (sqm_error "sqm_start_default: sqm_prepare_failed" && return 1)
     else
 	sqm_debug "sqm_start_default: no sqm_prepare_script function found, proceeding without."
     fi

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -438,7 +438,7 @@ verify_qdisc() {
         num_queues=$(ls -d /sys/class/net/$name/queues/tx-* | wc -l)
         if [ "$num_queues" -le "1" ]; then
             sqm_warning "ip could not create a multi tx queue device. \
-                Please install iputils-ip, if you want to use $qdisc."
+                Please install ip-full, if you want to use $qdisc."
         fi
         ;;
     esac

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -356,16 +356,14 @@ create_ifb() {
     local args
     local num_procs
     name=$1
-    use_mq=$2
     args=
 
     num_procs=$(grep -c processor /proc/cpuinfo)
 
-    if [ "$use_mq" = "1" ] && [ "$num_procs" -gt 1 ]; then
+    if [ "$QDISC" = "cake_mq" ] && [ "$num_procs" -gt 1 ]; then
         args="numtxqueues $num_procs"
     fi
-    $IP link add name $name $args type ifb || return false
-
+    $IP link add name $name $args type ifb
 }
 
 delete_ifb() {
@@ -411,7 +409,6 @@ verify_qdisc() {
     ifb=SQM_IFB_$randnum
     root_string="root" # this works for most qdiscs
     args=""
-    use_mq=0
     IFB_MTU=1514
 
     if [ -n "$supported" ]; then
@@ -421,8 +418,7 @@ verify_qdisc() {
         done
         [ "$found" -eq "1" ] || return 1
     fi
-    [ "$qdisc" = "cake_mq" ] && use_mq=1
-    create_ifb $ifb $use_mq || return 1
+    create_ifb $ifb || return 1
 
 
     case $qdisc in

--- a/src/functions.sh
+++ b/src/functions.sh
@@ -360,7 +360,7 @@ create_ifb() {
 
     num_procs=$(grep -c processor /proc/cpuinfo)
 
-    if [ "$QDISC" = "cake_mq" ] && [ "$num_procs" -gt 1 ]; then
+    if [ "$num_procs" -gt 1 ]; then
         args="numtxqueues $num_procs"
     fi
     $IP link add name $name $args type ifb
@@ -431,9 +431,9 @@ verify_qdisc() {
 	    args="limit 1 burst ${IFB_MTU} rate 1kbps"
 	    ;;
         cake_mq)
-        num_queues=$(ls -d /sys/class/net/$name/queues/tx-* | wc -l)
+        num_queues=$(ls -d /sys/class/net/$ifb/queues/tx-* | wc -l)
         if [ "$num_queues" -le "1" ]; then
-            sqm_warning "ip could not create a multi tx queue device. \
+            sqm_warn "ip could not create a multi tx queue device. \
                 Please install ip-full, if you want to use $qdisc."
         fi
         ;;

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -18,9 +18,14 @@
 
 egress() {
     SILENT=1 $TC qdisc del dev $IFACE root
+    num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
+    if [ "$QDISC" = "cake_mq" ] && [ "$num_queues" -le "1" ]; then
+        sqm_error "Hardware does not support multiple transmission queues. Cannot use cake_mq."
+        return 1
+    fi
+
     $TC qdisc add dev $IFACE root $( get_stab_string ) $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
-
 }
 
 

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -11,7 +11,6 @@
 
 #sm: TODO pass in the cake diffserv keyword
 
-SUPPORT_MQ=1
 . ${SQM_LIB_DIR}/defaults.sh
 QDISC=cake
 
@@ -19,18 +18,14 @@ QDISC=cake
 
 
 egress() {
-    local qdisc
-    qdisc=$(select_cake $IFACE)
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) $qdisc \
+    $TC qdisc add dev $IFACE root $( get_stab_string ) cake \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 
 }
 
 
 ingress() {
-    local qdisc
-    qdisc=$(select_cake $DEV)
 
     SILENT=1 $TC qdisc del dev $IFACE handle ffff: ingress
     $TC qdisc add dev $IFACE handle ffff: ingress
@@ -40,7 +35,7 @@ ingress() {
     [ "$IGNORE_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS besteffort"
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) $qdisc \
+    $TC qdisc add dev $DEV root $( get_stab_string ) cake \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -18,13 +18,8 @@
 
 egress() {
     SILENT=1 $TC qdisc del dev $IFACE root
-    num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
-    if [ "$QDISC" = "cake_mq" ] && [ "$num_queues" -le "1" ]; then
-        sqm_error "Hardware does not support multiple transmission queues. Cannot use cake_mq."
-        return 1
-    fi
 
-    $TC qdisc add dev $IFACE root $( get_stab_string ) $QDISC \
+    $TC qdisc add dev $IFACE root $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
 
@@ -39,7 +34,7 @@ ingress() {
     [ "$IGNORE_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS besteffort"
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) cake \
+    $TC qdisc add dev $DEV root $QDISC \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/layer_cake.qos
+++ b/src/layer_cake.qos
@@ -12,14 +12,13 @@
 #sm: TODO pass in the cake diffserv keyword
 
 . ${SQM_LIB_DIR}/defaults.sh
-QDISC=cake
 
 # Default traffic classication is passed in INGRESS_CAKE_OPTS and EGRESS_CAKE_OPTS, defined in defaults.sh now
 
 
 egress() {
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) cake \
+    $TC qdisc add dev $IFACE root $( get_stab_string ) $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 
 }
@@ -48,5 +47,5 @@ ingress() {
 
 sqm_prepare_script() {
     do_modules
-    verify_qdisc $QDISC "cake" || return 1
+    verify_qdisc $QDISC "cake cake_mq" || return 1
 }

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -9,7 +9,6 @@
 #       Copyright (C) 2012-5 Michael D. Taht, Toke Høiland-Jørgensen, Sebastian Moeller
 
 
-SUPPORT_MQ=1
 . ${SQM_LIB_DIR}/defaults.sh
 QDISC=cake
 
@@ -22,19 +21,15 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 
 
 egress() {
-    local qdisc
     sqm_debug "egress"
-    qdisc=$(select_cake $IFACE)
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) $qdisc \
+    $TC qdisc add dev $IFACE root $( get_stab_string ) cake \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
 
 
 ingress() {
-    local qdisc
     sqm_debug "ingress"
-    qdisc=$(select_cake $DEV)
 
     SILENT=1 $TC qdisc del dev $IFACE handle ffff: ingress
     $TC qdisc add dev $IFACE handle ffff: ingress
@@ -42,7 +37,7 @@ ingress() {
 
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) $qdisc \
+    $TC qdisc add dev $DEV root $( get_stab_string ) cake \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -21,6 +21,11 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 egress() {
     sqm_debug "egress"
     SILENT=1 $TC qdisc del dev $IFACE root
+    num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
+    if [ "$QDISC" = "cake_mq" ] && [ "$num_queues" -le "1" ]; then
+        sqm_error "Hardware does not support multiple transmission queues. Cannot use cake_mq."
+        return 1
+    fi
     $TC qdisc add dev $IFACE root $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -21,11 +21,6 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 egress() {
     sqm_debug "egress"
     SILENT=1 $TC qdisc del dev $IFACE root
-    num_queues=$(ls -d /sys/class/net/$IFACE/queues/tx-* | wc -l)
-    if [ "$QDISC" = "cake_mq" ] && [ "$num_queues" -le "1" ]; then
-        sqm_error "Hardware does not support multiple transmission queues. Cannot use cake_mq."
-        return 1
-    fi
     $TC qdisc add dev $IFACE root $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
@@ -40,7 +35,7 @@ ingress() {
 
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root cake \
+    $TC qdisc add dev $DEV root $QDISC \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up

--- a/src/piece_of_cake.qos
+++ b/src/piece_of_cake.qos
@@ -10,8 +10,6 @@
 
 
 . ${SQM_LIB_DIR}/defaults.sh
-QDISC=cake
-
 
 # to keep this as simple as possible we append the *_CAKE_OPTS from defaults.sh
 # since cake will always just keep the last instance of competing keywords this
@@ -23,7 +21,7 @@ EGRESS_CAKE_OPTS="${EGRESS_CAKE_OPTS} besteffort"
 egress() {
     sqm_debug "egress"
     SILENT=1 $TC qdisc del dev $IFACE root
-    $TC qdisc add dev $IFACE root $( get_stab_string ) cake \
+    $TC qdisc add dev $IFACE root $QDISC \
         bandwidth ${UPLINK}kbit $( get_cake_lla_string ) ${EGRESS_CAKE_OPTS} ${EQDISC_OPTS}
 }
 
@@ -37,7 +35,7 @@ ingress() {
 
     [ "$ZERO_DSCP_INGRESS" -eq "1" ] && INGRESS_CAKE_OPTS="$INGRESS_CAKE_OPTS wash"
 
-    $TC qdisc add dev $DEV root $( get_stab_string ) cake \
+    $TC qdisc add dev $DEV root cake \
         bandwidth ${DOWNLINK}kbit $( get_cake_lla_string ) ${INGRESS_CAKE_OPTS} ${IQDISC_OPTS}
 
     $IP link set dev $DEV up
@@ -50,5 +48,5 @@ ingress() {
 
 sqm_prepare_script() {
     do_modules
-    verify_qdisc $QDISC "cake" || return 1
+    verify_qdisc $QDISC "cake cake_mq" || return 1
 }

--- a/src/run-openwrt.sh
+++ b/src/run-openwrt.sh
@@ -66,7 +66,6 @@ start_sqm_section() {
     export TARGET=$(config_get "$section" target)
     export QDISC=$(config_get "$section" qdisc)
     export SCRIPT=$(config_get "$section" script)
-    export USE_MQ=$(config_get "$section" use_mq)
 
     # The UCI names for these two variables are confusing and should have been
     # changed ages ago. For now, keep the bad UCI names but use meaningful


### PR DESCRIPTION
This is a second version of handling the cake-mq installation correctly by using the QDISC variable as suggested by @moeller0 in #183 .
This will install cake_mq only when selected, and avoids installing cake_mq transparently.

create IFB: will now create multiple tx queues whenever there is more than one cpu. It does not affect any single queue qdisc configuration but makes it easier to handle a multi-queue qdisc config.

verify_qdisc: In case of cake_mq, if the created IFB device does not have multiple tx-queues we should fail.
verify_qdisc_for_if: Additionally check if the qdisc is about to be installed on the real device, that this device has multiple tx-queues.

This patch requires `ip` as dependency for this package